### PR TITLE
Suppress exceptions from toString methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ gradle-app.setting
 .idea/vcs.xml
 .idea/jsLibraryMappings.xml
 local.properties
+kotlin-logging.iml
 
 # Sensitive or high-churn files:
 .idea/dataSources.ids

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ gradle-app.setting
 .idea/dictionaries
 .idea/vcs.xml
 .idea/jsLibraryMappings.xml
+local.properties
 
 # Sensitive or high-churn files:
 .idea/dataSources.ids

--- a/src/main/kotlin/mu/KLogger.kt
+++ b/src/main/kotlin/mu/KLogger.kt
@@ -1,5 +1,6 @@
 package mu
 
+import mu.internal.toStringSafe
 import org.slf4j.Logger
 
 /**
@@ -13,69 +14,69 @@ interface KLogger: Logger{
      * Lazy add a log message if isTraceEnabled is true
      */
     fun trace(msg: () -> Any?) {
-        if (isTraceEnabled) trace(msg.invoke().toString())
+        if (isTraceEnabled) trace(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isDebugEnabled is true
      */
     fun debug(msg: () -> Any?) {
-        if (isDebugEnabled) debug(msg.invoke().toString())
+        if (isDebugEnabled) debug(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isInfoEnabled is true
      */
     fun info(msg: () -> Any?) {
-        if (isInfoEnabled) info(msg.invoke().toString())
+        if (isInfoEnabled) info(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isWarnEnabled is true
      */
     fun warn(msg: () -> Any?) {
-        if (isWarnEnabled) warn(msg.invoke().toString())
+        if (isWarnEnabled) warn(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isErrorEnabled is true
      */
     fun error(msg: () -> Any?) {
-        if (isErrorEnabled) error(msg.invoke().toString())
+        if (isErrorEnabled) error(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message with throwable payload if isTraceEnabled is true
      */
     fun trace(t: Throwable, msg: () -> Any?) {
-        if (isTraceEnabled) trace(msg.invoke().toString(), t)
+        if (isTraceEnabled) trace(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isDebugEnabled is true
      */
     fun debug(t: Throwable, msg: () -> Any?) {
-        if (isDebugEnabled) debug(msg.invoke().toString(), t)
+        if (isDebugEnabled) debug(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isInfoEnabled is true
      */
     fun info(t: Throwable, msg: () -> Any?) {
-        if (isInfoEnabled) info(msg.invoke().toString(), t)
+        if (isInfoEnabled) info(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isWarnEnabled is true
      */
     fun warn(t: Throwable, msg: () -> Any?) {
-        if (isWarnEnabled) warn(msg.invoke().toString(), t)
+        if (isWarnEnabled) warn(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isErrorEnabled is true
      */
     fun error(t: Throwable, msg: () -> Any?) {
-        if (isErrorEnabled) error(msg.invoke().toString(), t)
+        if (isErrorEnabled) error(msg.toStringSafe(), t)
     }
 }

--- a/src/main/kotlin/mu/internal/LocationAwareKLogger.kt
+++ b/src/main/kotlin/mu/internal/LocationAwareKLogger.kt
@@ -478,69 +478,69 @@ internal class LocationAwareKLogger(private val jLogger: LocationAwareLogger) : 
      * Lazy add a log message if isTraceEnabled is true
      */
     override fun trace(msg: () -> Any?) {
-        if (isTraceEnabled) trace(msg.invoke().toString())
+        if (isTraceEnabled) trace(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isDebugEnabled is true
      */
     override fun debug(msg: () -> Any?) {
-        if (isDebugEnabled) debug(msg.invoke().toString())
+        if (isDebugEnabled) debug(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isInfoEnabled is true
      */
     override fun info(msg: () -> Any?) {
-        if (isInfoEnabled) info(msg.invoke().toString())
+        if (isInfoEnabled) info(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isWarnEnabled is true
      */
     override fun warn(msg: () -> Any?) {
-        if (isWarnEnabled) warn(msg.invoke().toString())
+        if (isWarnEnabled) warn(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isErrorEnabled is true
      */
     override fun error(msg: () -> Any?) {
-        if (isErrorEnabled) error(msg.invoke().toString())
+        if (isErrorEnabled) error(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message with throwable payload if isTraceEnabled is true
      */
     override fun trace(t: Throwable, msg: () -> Any?) {
-        if (isTraceEnabled) trace(msg.invoke().toString(), t)
+        if (isTraceEnabled) trace(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isDebugEnabled is true
      */
     override fun debug(t: Throwable, msg: () -> Any?) {
-        if (isDebugEnabled) debug(msg.invoke().toString(), t)
+        if (isDebugEnabled) debug(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isInfoEnabled is true
      */
     override fun info(t: Throwable, msg: () -> Any?) {
-        if (isInfoEnabled) info(msg.invoke().toString(), t)
+        if (isInfoEnabled) info(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isWarnEnabled is true
      */
     override fun warn(t: Throwable, msg: () -> Any?) {
-        if (isWarnEnabled) warn(msg.invoke().toString(), t)
+        if (isWarnEnabled) warn(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isErrorEnabled is true
      */
     override fun error(t: Throwable, msg: () -> Any?) {
-        if (isErrorEnabled) error(msg.invoke().toString(), t)
+        if (isErrorEnabled) error(msg.toStringSafe(), t)
     }
 }

--- a/src/main/kotlin/mu/internal/MessageInvoker.kt
+++ b/src/main/kotlin/mu/internal/MessageInvoker.kt
@@ -2,7 +2,7 @@ package mu.internal
 
 internal fun (() -> Any?).toStringSafe(): String {
     try{
-        return toString()
+        return invoke().toString()
     }catch (ex: Exception){
         return "Execution of $this failed: $ex"
     }

--- a/src/main/kotlin/mu/internal/MessageInvoker.kt
+++ b/src/main/kotlin/mu/internal/MessageInvoker.kt
@@ -1,0 +1,9 @@
+package mu.internal
+
+internal fun (() -> Any?).toStringSafe(): String {
+    try{
+        return toString()
+    }catch (ex: Exception){
+        return "Execution of $this failed: $ex"
+    }
+}

--- a/src/test/kotlin/mu/LoggingTest.kt
+++ b/src/test/kotlin/mu/LoggingTest.kt
@@ -52,6 +52,22 @@ class ChildClassWithLogging {
         logger.info{"test ChildClassWithLogging"}
     }
 }
+
+data class ClassWithIncorrectToString(val someVariable : String? = null){
+    override fun toString(): String {
+        return someVariable!!.toString()
+    }
+}
+
+class LambdaRaisesError {
+    companion object: KLogging()
+    fun test() {
+        val problematicClass = ClassWithIncorrectToString()
+
+        logger.info{" $problematicClass"}
+    }
+}
+
 class LoggingTest {
     private lateinit var appenderWithWriter: AppenderWithWriter
 
@@ -102,6 +118,12 @@ class LoggingTest {
     fun testMessages6() {
         CompanionHasLogging().test()
         Assert.assertEquals("INFO  mu.CompanionHasLogging  - test CompanionHasLogging", appenderWithWriter.writer.toString().trim())
+    }
+
+    @Test
+    fun shouldNotFailForFailingLambdas(){
+        LambdaRaisesError().test()
+        Assert.assertEquals("INFO  mu.LambdaRaisesError  - Execution of Function0<java.lang.String> failed: kotlin.KotlinNullPointerException", appenderWithWriter.writer.toString().trim())
     }
 }
 class LoggingNameTest {


### PR DESCRIPTION
Sometimes classes have incorrect toString implementation, which raises exception.

To avoid this, logger should cautch and inform developer.

Such behavior is used in the many popular loggers, we should reuse it too