### PR TITLE
Accept nullable Throwables (#38)

### DIFF
--- a/kotlin-logging-jvm/src/main/kotlin/mu/KLogger.kt
+++ b/kotlin-logging-jvm/src/main/kotlin/mu/KLogger.kt
@@ -53,35 +53,35 @@ interface KLogger : Logger {
   /**
    * Lazy add a log message with throwable payload if isTraceEnabled is true
    */
-  fun trace(t: Throwable, msg: () -> Any?) {
+  fun trace(t: Throwable?, msg: () -> Any?) {
     if (isTraceEnabled) trace(msg.toStringSafe(), t)
   }
 
   /**
    * Lazy add a log message with throwable payload if isDebugEnabled is true
    */
-  fun debug(t: Throwable, msg: () -> Any?) {
+  fun debug(t: Throwable?, msg: () -> Any?) {
     if (isDebugEnabled) debug(msg.toStringSafe(), t)
   }
 
   /**
    * Lazy add a log message with throwable payload if isInfoEnabled is true
    */
-  fun info(t: Throwable, msg: () -> Any?) {
+  fun info(t: Throwable?, msg: () -> Any?) {
     if (isInfoEnabled) info(msg.toStringSafe(), t)
   }
 
   /**
    * Lazy add a log message with throwable payload if isWarnEnabled is true
    */
-  fun warn(t: Throwable, msg: () -> Any?) {
+  fun warn(t: Throwable?, msg: () -> Any?) {
     if (isWarnEnabled) warn(msg.toStringSafe(), t)
   }
 
   /**
    * Lazy add a log message with throwable payload if isErrorEnabled is true
    */
-  fun error(t: Throwable, msg: () -> Any?) {
+  fun error(t: Throwable?, msg: () -> Any?) {
     if (isErrorEnabled) error(msg.toStringSafe(), t)
   }
 }

--- a/kotlin-logging-jvm/src/main/kotlin/mu/internal/LocationAwareKLogger.kt
+++ b/kotlin-logging-jvm/src/main/kotlin/mu/internal/LocationAwareKLogger.kt
@@ -512,35 +512,35 @@ internal class LocationAwareKLogger(override val underlyingLogger: LocationAware
     /**
      * Lazy add a log message with throwable payload if isTraceEnabled is true
      */
-    override fun trace(t: Throwable, msg: () -> Any?) {
+    override fun trace(t: Throwable?, msg: () -> Any?) {
         if (isTraceEnabled) trace(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isDebugEnabled is true
      */
-    override fun debug(t: Throwable, msg: () -> Any?) {
+    override fun debug(t: Throwable?, msg: () -> Any?) {
         if (isDebugEnabled) debug(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isInfoEnabled is true
      */
-    override fun info(t: Throwable, msg: () -> Any?) {
+    override fun info(t: Throwable?, msg: () -> Any?) {
         if (isInfoEnabled) info(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isWarnEnabled is true
      */
-    override fun warn(t: Throwable, msg: () -> Any?) {
+    override fun warn(t: Throwable?, msg: () -> Any?) {
         if (isWarnEnabled) warn(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isErrorEnabled is true
      */
-    override fun error(t: Throwable, msg: () -> Any?) {
+    override fun error(t: Throwable?, msg: () -> Any?) {
         if (isErrorEnabled) error(msg.toStringSafe(), t)
     }
 }

--- a/kotlin-logging-jvm/src/test/kotlin/mu/LoggingTest.kt
+++ b/kotlin-logging-jvm/src/test/kotlin/mu/LoggingTest.kt
@@ -17,6 +17,10 @@ class ClassWithLogging {
         val ex = Throwable()
         logger.trace(ex){"test ChildClassWithLogging"}
     }
+    fun testNullableThrowable() {
+        val ex:Throwable? = null
+        logger.trace(ex){"test ChildClassWithLogging"}
+    }
 }
 open class ClassHasLogging: KLoggable {
     override val logger = logger()
@@ -87,12 +91,14 @@ class LoggingTest {
         ClassWithLogging().apply {
             test()
             testThrowable()
+            testNullableThrowable()
         }
         val lines = appenderWithWriter.writer.toString().trim().replace("\r", "\n").replace("\n\n", "\n").split("\n")
         Assert.assertEquals("INFO  mu.ClassWithLogging  - test ClassWithLogging", lines[0].trim())
         Assert.assertEquals("TRACE mu.ClassWithLogging  - test ChildClassWithLogging", lines[1].trim())
         Assert.assertEquals("java.lang.Throwable", lines[2].trim())
         Assert.assertTrue(lines[3].trim().startsWith("at mu.ClassWithLogging.testThrowable("))
+        Assert.assertEquals("TRACE mu.ClassWithLogging  - test ChildClassWithLogging", lines[lines.size-1].trim())
     }
     @Test
     fun testMessages2() {


### PR DESCRIPTION
This change simply accepts `Throwable?` instead of `Throwable`. Slf4j treats ignores null throwables.