### PR TITLE
Javascript - Extracting Message Formatter interface

### DIFF
--- a/kotlin-logging-js/src/main/kotlin/mu/ConsoleOutputPipes.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/ConsoleOutputPipes.kt
@@ -1,0 +1,9 @@
+package mu
+
+object ConsoleOutputPipes : OutputPipes {
+    override fun trace(message: Any?) = console.log(message)
+    override fun debug(message: Any?) = console.log(message)
+    override fun info(message: Any?) = console.info(message)
+    override fun warn(message: Any?) = console.warn(message)
+    override fun error(message: Any?) = console.error(message)
+}

--- a/kotlin-logging-js/src/main/kotlin/mu/DefaultMessageFormatter.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/DefaultMessageFormatter.kt
@@ -1,0 +1,30 @@
+package mu
+
+import mu.internal.toStringSafe
+
+object DefaultMessageFormatter : MessageFormatter {
+    override fun formatMessage(level: KotlinLoggingLevel, msg: () -> Any?, loggerName: String) =
+            "${level.name}: [$loggerName] ${msg.toStringSafe()}"
+
+    override fun formatMessage(level: KotlinLoggingLevel, msg: () -> Any?, t: Throwable?, loggerName: String) =
+            "${level.name}: [$loggerName] ${msg.toStringSafe()}${t.throwableToString()}"
+
+    override fun formatMessage(level: KotlinLoggingLevel, marker: Marker?, msg: () -> Any?, loggerName: String) =
+            "${level.name}: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}"
+
+    override fun formatMessage(level: KotlinLoggingLevel, marker: Marker?, msg: () -> Any?, t: Throwable?, loggerName: String) =
+            "${level.name}: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}${t.throwableToString()}"
+
+    private fun Throwable?.throwableToString(): String {
+        if (this == null) {
+            return ""
+        }
+        var msg = ""
+        var current = this
+        while (current != null && current.cause != current) {
+            msg += ", Caused by: '${current.message}'"
+            current = current.cause
+        }
+        return msg
+    }
+}

--- a/kotlin-logging-js/src/main/kotlin/mu/DefaultMessageFormatter.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/DefaultMessageFormatter.kt
@@ -3,16 +3,16 @@ package mu
 import mu.internal.toStringSafe
 
 object DefaultMessageFormatter : MessageFormatter {
-    override fun formatMessage(level: KotlinLoggingLevel, msg: () -> Any?, loggerName: String) =
+    override fun formatMessage(level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?) =
             "${level.name}: [$loggerName] ${msg.toStringSafe()}"
 
-    override fun formatMessage(level: KotlinLoggingLevel, msg: () -> Any?, t: Throwable?, loggerName: String) =
+    override fun formatMessage(level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?) =
             "${level.name}: [$loggerName] ${msg.toStringSafe()}${t.throwableToString()}"
 
-    override fun formatMessage(level: KotlinLoggingLevel, marker: Marker?, msg: () -> Any?, loggerName: String) =
+    override fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?) =
             "${level.name}: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}"
 
-    override fun formatMessage(level: KotlinLoggingLevel, marker: Marker?, msg: () -> Any?, t: Throwable?, loggerName: String) =
+    override fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, t: Throwable?, msg: () -> Any?) =
             "${level.name}: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}${t.throwableToString()}"
 
     private fun Throwable?.throwableToString(): String {

--- a/kotlin-logging-js/src/main/kotlin/mu/KotlinLoggingLevel.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/KotlinLoggingLevel.kt
@@ -11,3 +11,6 @@ enum class KotlinLoggingLevel {
 }
 
 fun KotlinLoggingLevel.isLoggingEnabled() = this.ordinal >= LOG_LEVEL.ordinal
+
+var outputPipes = ConsoleOutputPipes
+var messageFormatter = DefaultMessageFormatter

--- a/kotlin-logging-js/src/main/kotlin/mu/MessageFormatter.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/MessageFormatter.kt
@@ -1,8 +1,8 @@
 package mu
 
 interface MessageFormatter {
-    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?): String
-    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?): String
-    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?): String
-    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, t: Throwable?, msg: () -> Any?): String
+    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?): Any?
+    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?): Any?
+    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?): Any?
+    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, t: Throwable?, msg: () -> Any?): Any?
 }

--- a/kotlin-logging-js/src/main/kotlin/mu/MessageFormatter.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/MessageFormatter.kt
@@ -1,0 +1,8 @@
+package mu
+
+interface MessageFormatter {
+    fun formatMessage(level: KotlinLoggingLevel, msg: () -> Any?, loggerName: String): String
+    fun formatMessage(level: KotlinLoggingLevel, msg: () -> Any?, t: Throwable?, loggerName: String): String
+    fun formatMessage(level: KotlinLoggingLevel, marker: Marker?, msg: () -> Any?, loggerName: String): String
+    fun formatMessage(level: KotlinLoggingLevel, marker: Marker?, msg: () -> Any?, t: Throwable?, loggerName: String): String
+}

--- a/kotlin-logging-js/src/main/kotlin/mu/MessageFormatter.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/MessageFormatter.kt
@@ -1,8 +1,8 @@
 package mu
 
 interface MessageFormatter {
-    fun formatMessage(level: KotlinLoggingLevel, msg: () -> Any?, loggerName: String): String
-    fun formatMessage(level: KotlinLoggingLevel, msg: () -> Any?, t: Throwable?, loggerName: String): String
-    fun formatMessage(level: KotlinLoggingLevel, marker: Marker?, msg: () -> Any?, loggerName: String): String
-    fun formatMessage(level: KotlinLoggingLevel, marker: Marker?, msg: () -> Any?, t: Throwable?, loggerName: String): String
+    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?): String
+    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?): String
+    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?): String
+    fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, t: Throwable?, msg: () -> Any?): String
 }

--- a/kotlin-logging-js/src/main/kotlin/mu/OutputPipes.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/OutputPipes.kt
@@ -1,0 +1,9 @@
+package mu
+
+interface OutputPipes {
+    fun trace(message: Any?)
+    fun debug(message: Any?)
+    fun info(message: Any?)
+    fun warn(message: Any?)
+    fun error(message: Any?)
+}

--- a/kotlin-logging-js/src/main/kotlin/mu/internal/KLoggerJS.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/internal/KLoggerJS.kt
@@ -1,142 +1,76 @@
 package mu.internal
 
-import mu.KLogger
-import mu.KotlinLoggingLevel
-import mu.Marker
-import mu.isLoggingEnabled
+import mu.*
+import mu.KotlinLoggingLevel.*
 
-internal class KLoggerJS(private val loggerName: String) : KLogger {
+internal class KLoggerJS(
+        private val loggerName: String,
+        private val pipes: OutputPipes = outputPipes,
+        private val formatter: MessageFormatter = messageFormatter
+) : KLogger, MessageFormatter by formatter {
 
-    override fun trace(msg: () -> Any?) {
-        if (KotlinLoggingLevel.TRACE.isLoggingEnabled()) {
-            console.log("TRACE: [$loggerName] ${msg.toStringSafe()}")
+    override fun trace(msg: () -> Any?) = TRACE.logIfEnabled(msg, pipes::trace)
+
+    override fun debug(msg: () -> Any?) = DEBUG.logIfEnabled(msg, pipes::debug)
+
+    override fun info(msg: () -> Any?) = INFO.logIfEnabled(msg, pipes::info)
+
+    override fun warn(msg: () -> Any?) = WARN.logIfEnabled(msg, pipes::warn)
+
+    override fun error(msg: () -> Any?) = ERROR.logIfEnabled(msg, pipes::error)
+
+    override fun trace(t: Throwable?, msg: () -> Any?) = TRACE.logIfEnabled(msg, t, pipes::trace)
+
+    override fun debug(t: Throwable?, msg: () -> Any?) = DEBUG.logIfEnabled(msg, t, pipes::debug)
+
+    override fun info(t: Throwable?, msg: () -> Any?) = INFO.logIfEnabled(msg, t, pipes::info)
+
+    override fun warn(t: Throwable?, msg: () -> Any?) = WARN.logIfEnabled(msg, t, pipes::warn)
+
+    override fun error(t: Throwable?, msg: () -> Any?) = ERROR.logIfEnabled(msg, t, pipes::error)
+
+    override fun trace(marker: Marker?, msg: () -> Any?) = TRACE.logIfEnabled(marker, msg, pipes::trace)
+
+    override fun debug(marker: Marker?, msg: () -> Any?) = DEBUG.logIfEnabled(marker, msg, pipes::debug)
+
+    override fun info(marker: Marker?, msg: () -> Any?) = INFO.logIfEnabled(marker, msg, pipes::info)
+
+    override fun warn(marker: Marker?, msg: () -> Any?) = WARN.logIfEnabled(marker, msg, pipes::warn)
+
+    override fun error(marker: Marker?, msg: () -> Any?) = ERROR.logIfEnabled(marker, msg, pipes::error)
+
+    override fun trace(marker: Marker?, t: Throwable?, msg: () -> Any?) = TRACE.logIfEnabled(marker, msg, t, pipes::trace)
+
+    override fun debug(marker: Marker?, t: Throwable?, msg: () -> Any?) = DEBUG.logIfEnabled(marker, msg, t, pipes::debug)
+
+    override fun info(marker: Marker?, t: Throwable?, msg: () -> Any?) = INFO.logIfEnabled(marker, msg, t, pipes::info)
+
+    override fun warn(marker: Marker?, t: Throwable?, msg: () -> Any?) = WARN.logIfEnabled(marker, msg, t, pipes::warn)
+
+    override fun error(marker: Marker?, t: Throwable?, msg: () -> Any?) = ERROR.logIfEnabled(marker, msg, t, pipes::error)
+
+    private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, logFunction: (Any?) -> Unit) {
+        if (isLoggingEnabled()) {
+            logFunction(formatMessage(this, msg, loggerName))
         }
     }
 
-    override fun debug(msg: () -> Any?) {
-        if (KotlinLoggingLevel.DEBUG.isLoggingEnabled()) {
-            console.log("DEBUG: [$loggerName] ${msg.toStringSafe()}")
+    private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, t: Throwable?, logFunction: (Any?) -> Unit) {
+        if (isLoggingEnabled()) {
+            logFunction(formatMessage(this, msg, t, loggerName))
         }
     }
 
-    override fun info(msg: () -> Any?) {
-        if (KotlinLoggingLevel.INFO.isLoggingEnabled()) {
-            console.info("INFO: [$loggerName] ${msg.toStringSafe()}")
+    private fun KotlinLoggingLevel.logIfEnabled(marker: Marker?, msg: () -> Any?, logFunction: (Any?) -> Unit) {
+        if (isLoggingEnabled()) {
+            logFunction(formatMessage(this, marker, msg, loggerName))
         }
     }
 
-    override fun warn(msg: () -> Any?) {
-        if (KotlinLoggingLevel.WARN.isLoggingEnabled()) {
-            console.warn("WARN: [$loggerName] ${msg.toStringSafe()}")
+    private fun KotlinLoggingLevel.logIfEnabled(marker: Marker?, msg: () -> Any?, t: Throwable?, logFunction: (Any?) -> Unit) {
+        if (isLoggingEnabled()) {
+            logFunction(formatMessage(this, marker, msg, t, loggerName))
         }
     }
 
-    override fun error(msg: () -> Any?) {
-        if (KotlinLoggingLevel.ERROR.isLoggingEnabled()) {
-            console.error("ERROR: [$loggerName] ${msg.toStringSafe()}")
-        }
-    }
-
-    override fun trace(t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.TRACE.isLoggingEnabled()) {
-            console.log("TRACE: [$loggerName] ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    override fun debug(t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.DEBUG.isLoggingEnabled()) {
-            console.log("DEBUG: [$loggerName] ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    override fun info(t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.INFO.isLoggingEnabled()) {
-            console.info("INFO: [$loggerName] ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    override fun warn(t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.WARN.isLoggingEnabled()) {
-            console.warn("WARN: [$loggerName] ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    override fun error(t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.ERROR.isLoggingEnabled()) {
-            console.error("ERROR: [$loggerName] ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    override fun trace(marker: Marker?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.TRACE.isLoggingEnabled()) {
-            console.log("TRACE: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}")
-        }
-    }
-
-    override fun debug(marker: Marker?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.DEBUG.isLoggingEnabled()) {
-            console.log("DEBUG: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}")
-        }
-    }
-
-    override fun info(marker: Marker?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.INFO.isLoggingEnabled()) {
-            console.info("INFO: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}")
-        }
-    }
-
-    override fun warn(marker: Marker?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.WARN.isLoggingEnabled()) {
-            console.warn("WARN: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}")
-        }
-    }
-
-    override fun error(marker: Marker?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.ERROR.isLoggingEnabled()) {
-            console.error("ERROR: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}")
-        }
-    }
-
-    override fun trace(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.TRACE.isLoggingEnabled()) {
-            console.log("TRACE: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    override fun debug(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.DEBUG.isLoggingEnabled()) {
-            console.log("DEBUG: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    override fun info(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.INFO.isLoggingEnabled()) {
-            console.info("INFO: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    override fun warn(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.WARN.isLoggingEnabled()) {
-            console.warn("WARN: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    override fun error(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (KotlinLoggingLevel.ERROR.isLoggingEnabled()) {
-            console.error("ERROR: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}${t.throwableToString()}")
-        }
-    }
-
-    private fun Throwable?.throwableToString(): String {
-        if (this == null) {
-            return ""
-        }
-        var msg = ""
-        var current = this
-        while (current != null && current.cause != current) {
-            msg += ", Caused by: '${current.message}'"
-            current = current.cause
-        }
-        return msg
-    }
 }

--- a/kotlin-logging-js/src/main/kotlin/mu/internal/KLoggerJS.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/internal/KLoggerJS.kt
@@ -51,25 +51,25 @@ internal class KLoggerJS(
 
     private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatMessage(this, msg, loggerName))
+            logFunction(formatMessage(this, loggerName, msg))
         }
     }
 
     private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, t: Throwable?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatMessage(this, msg, t, loggerName))
+            logFunction(formatMessage(this, loggerName, t, msg))
         }
     }
 
     private fun KotlinLoggingLevel.logIfEnabled(marker: Marker?, msg: () -> Any?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatMessage(this, marker, msg, loggerName))
+            logFunction(formatMessage(this, loggerName, marker, msg))
         }
     }
 
     private fun KotlinLoggingLevel.logIfEnabled(marker: Marker?, msg: () -> Any?, t: Throwable?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatMessage(this, marker, msg, t, loggerName))
+            logFunction(formatMessage(this, loggerName, marker, t, msg))
         }
     }
 


### PR DESCRIPTION
So mostly this is freehand refactoring (it'd be nice to add a test suite to the JS side here). But additionally, there are two new JS configurable variables at the root, such that someone using the library can modify or replace the message formatting.

I quick put this together because I was adding some logging to an app I've been converting to Kotlin-Js, and couldn't quite get it to produce JSON log lines rather than traditional ones. 🤷🏻‍♂️