### PR TITLE
added support for same functionality as slf4j-ext.

### DIFF
--- a/kotlin-logging-common/src/main/kotlin/mu/KLogger.kt
+++ b/kotlin-logging-common/src/main/kotlin/mu/KLogger.kt
@@ -104,4 +104,30 @@ expect interface KLogger {
    * Lazy add a log message with a marker and throwable payload if isErrorEnabled is true
    */
   fun error(marker: Marker?, t: Throwable?, msg: () -> Any?)
+
+  /**
+   * Add a log message with all the supplied parameters along with method name
+   */
+  fun entry(vararg argArray: Any)
+
+  /**
+   * Add log message indicating exit of a method
+   */
+  fun exit()
+
+  /**
+   * Add a log message with the return value of a method
+   */
+  fun <T> exit(retval: T): T where T : Any
+
+  /**
+   * Add a log message indicating an exception will be thrown along with the stack trace.
+   */
+  fun <T> throwing(throwable: T): T where T : Throwable
+
+  /**
+   * Add a log message indicating an exception is caught along with the stack trace.
+   */
+  fun <T> catching(throwable: T) where T : Throwable
+
 }

--- a/kotlin-logging-js/src/main/kotlin/mu/KLogger.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/KLogger.kt
@@ -105,4 +105,28 @@ actual interface KLogger {
    */
   actual fun error(marker: Marker?, t: Throwable?, msg: () -> Any?)
 
+  /**
+   * Add a log message with all the supplied parameters along with method name
+   */
+  actual fun entry(vararg argArray: Any)
+
+  /**
+   * Add log message indicating exit of a method
+   */
+  actual fun exit()
+
+  /**
+   * Add a log message with the return value of a method
+   */
+  actual fun <T> exit(retval: T): T where T : Any
+
+  /**
+   * Add a log message indicating an exception will be thrown along with the stack trace.
+   */
+  actual fun <T> throwing(throwable: T): T where T : Throwable
+
+  /**
+   * Add a log message indicating an exception is caught along with the stack trace.
+   */
+  actual fun <T> catching(throwable: T) where T : Throwable
 }

--- a/kotlin-logging-js/src/main/kotlin/mu/internal/KLoggerJS.kt
+++ b/kotlin-logging-js/src/main/kotlin/mu/internal/KLoggerJS.kt
@@ -4,16 +4,12 @@ import mu.KLogger
 import mu.KotlinLoggingConfiguration.APPENDER
 import mu.KotlinLoggingConfiguration.FORMATTER
 import mu.KotlinLoggingLevel
-import mu.KotlinLoggingLevel.DEBUG
-import mu.KotlinLoggingLevel.ERROR
-import mu.KotlinLoggingLevel.INFO
-import mu.KotlinLoggingLevel.TRACE
-import mu.KotlinLoggingLevel.WARN
+import mu.KotlinLoggingLevel.*
 import mu.Marker
 import mu.isLoggingEnabled
 
 internal class KLoggerJS(
-    private val loggerName: String
+        private val loggerName: String
 ) : KLogger {
 
     override fun trace(msg: () -> Any?) = TRACE.logIfEnabled(msg, APPENDER::trace)
@@ -80,4 +76,25 @@ internal class KLoggerJS(
         }
     }
 
+    override fun entry(vararg argArray: Any) {
+        TRACE.logIfEnabled({ "entry($argArray)" }, APPENDER::trace)
+    }
+
+    override fun exit() {
+        TRACE.logIfEnabled({ "exit()" }, APPENDER::trace)
+    }
+
+    override fun <T : Any> exit(retval: T): T {
+        TRACE.logIfEnabled({ "exut($retval)" }, APPENDER::trace)
+        return retval
+    }
+
+    override fun <T : Throwable> throwing(throwable: T): T {
+        ERROR.logIfEnabled({ "throwing($throwable" }, throwable, APPENDER::error)
+        return throwable
+    }
+
+    override fun <T : Throwable> catching(throwable: T) {
+        ERROR.logIfEnabled({ "catching($throwable" }, throwable, APPENDER::error)
+    }
 }

--- a/kotlin-logging-jvm/src/main/kotlin/mu/KLogger.kt
+++ b/kotlin-logging-jvm/src/main/kotlin/mu/KLogger.kt
@@ -114,4 +114,28 @@ actual interface KLogger : Logger {
    */
   actual fun error(marker: Marker?, t: Throwable?, msg: () -> Any?)
 
+  /**
+   * Add a log message with all the supplied parameters along with method name
+   */
+  actual fun entry(vararg argArray: Any)
+
+  /**
+   * Add log message indicating exit of a method
+   */
+  actual fun exit()
+
+  /**
+   * Add a log message with the return value of a method
+   */
+  actual fun <T> exit(retval: T): T where T : Any
+
+  /**
+   * Add a log message indicating an exception will be thrown along with the stack trace.
+   */
+  actual fun <T> throwing(throwable: T): T where T : Throwable
+
+  /**
+   * Add a log message indicating an exception is caught along with the stack trace.
+   */
+  actual fun <T> catching(throwable: T) where T : Throwable
 }

--- a/kotlin-logging-jvm/src/main/kotlin/mu/internal/LocationIgnorantKLogger.kt
+++ b/kotlin-logging-jvm/src/main/kotlin/mu/internal/LocationIgnorantKLogger.kt
@@ -152,4 +152,35 @@ internal class LocationIgnorantKLogger(override val underlyingLogger: Logger)
     override fun error(marker: Marker?, t: Throwable?, msg: () -> Any?) {
         if (isErrorEnabled) error(marker, msg.toStringSafe(), t)
     }
+    override inline fun entry(vararg argArray: Any) {
+        if (underlyingLogger.isTraceEnabled) {
+            underlyingLogger.trace("entry({})", argArray)
+        }
+    }
+
+    override inline fun exit() {
+        if (underlyingLogger.isTraceEnabled) {
+            underlyingLogger.trace("exit")
+        }
+    }
+
+    override inline fun <T : Any> exit(retval: T): T {
+        if (underlyingLogger.isTraceEnabled) {
+            underlyingLogger.trace("exit({}}", retval)
+        }
+        return retval
+    }
+
+    override inline fun  <T : Throwable> throwing(throwable: T): T {
+        if (underlyingLogger.isErrorEnabled) {
+            underlyingLogger.error("throwing($throwable)", throwable)
+        }
+        return throwable
+    }
+
+    override inline fun  <T : Throwable> catching(throwable: T) {
+        if (underlyingLogger.isErrorEnabled) {
+            underlyingLogger.error("catching($throwable)", throwable)
+        }
+    }
 }

--- a/kotlin-logging-jvm/src/test/kotlin/mu/ClassWithLoggingForLocationTesting.kt
+++ b/kotlin-logging-jvm/src/test/kotlin/mu/ClassWithLoggingForLocationTesting.kt
@@ -14,4 +14,10 @@ class ClassWithLoggingForLocationTesting {
     fun logNull() {
         logger.info(null)
     }
+
+    fun logEntry() {
+        logger.entry(1, 2)
+        logger.info("log entry body")
+        logger.exit(2)
+    }
 }

--- a/kotlin-logging-jvm/src/test/kotlin/mu/LoggingWithLocationTest.kt
+++ b/kotlin-logging-jvm/src/test/kotlin/mu/LoggingWithLocationTest.kt
@@ -33,6 +33,13 @@ class LoggingWithLocationTest {
         ClassWithLoggingForLocationTesting().logNull()
         Assert.assertEquals("INFO ClassWithLoggingForLocationTesting.logNull(15) - null", appenderWithWriter.writer.toString().trim())
     }
+    @Test
+    fun testNullLoggingWithLocationEntryExit() {
+        ClassWithLoggingForLocationTesting().logEntry()
+        Assert.assertEquals("TRACE ClassWithLoggingForLocationTesting.logEntry(19) -  entry with (1, 2)\n" +
+                "INFO ClassWithLoggingForLocationTesting.logEntry(20) - log entry body\n" +
+                "TRACE ClassWithLoggingForLocationTesting.logEntry(21) - exit with (2)", appenderWithWriter.writer.toString().trim())
+    }
 }
 
 


### PR DESCRIPTION
This PR only adds the entry, exit, throwing and catching methods to the existing logger.
The location-aware logger will add method names etc.
The LocationIgnorant and JS implementations are similar.
We may want to add markers.