### PR TITLE
add extension function and extension property for getting logger

### DIFF
--- a/kotlin-logging-jvm/src/main/kotlin/mu/KotlinLoggingExtension.kt
+++ b/kotlin-logging-jvm/src/main/kotlin/mu/KotlinLoggingExtension.kt
@@ -1,0 +1,38 @@
+package mu
+
+import mu.internal.KLoggerNameResolver
+import kotlin.reflect.KProperty
+
+inline fun <reified T : Any> T.logger(): KLogger =
+    KotlinLogging.logger(
+        @Suppress("NON_PUBLIC_CALL_FROM_PUBLIC_INLINE")
+        KLoggerNameResolver.name(forClass = T::class.java)
+    )
+
+val <T : Any> T.log: KLogger by LoggerLoader()
+
+private class LoggerLoader<T : Any> {
+    private val loggers: MutableMap<Class<*>, KLogger> = mutableMapOf()
+
+    operator fun getValue(thisRef: T, property: KProperty<*>): KLogger {
+        val instanceClass = thisRef::class.java
+        val v1 = loggers[instanceClass]
+        if (v1 !== null) {
+            return v1
+        }
+
+        return synchronized(this) {
+            val v2 = loggers[instanceClass]
+            if (v2 !== null) {
+                v2
+            } else {
+                val loggerForClass = KotlinLogging.logger(
+                    @Suppress("NON_PUBLIC_CALL_FROM_PUBLIC_INLINE")
+                    KLoggerNameResolver.name(forClass = instanceClass)
+                )
+                loggers[instanceClass] = loggerForClass
+                loggerForClass
+            }
+        }
+    }
+}

--- a/kotlin-logging-jvm/src/test/kotlin/mu/KotlinLoggingExtensionTest.kt
+++ b/kotlin-logging-jvm/src/test/kotlin/mu/KotlinLoggingExtensionTest.kt
@@ -1,0 +1,55 @@
+package mu
+
+import org.junit.Assert
+import org.junit.Test
+
+class TestClass01 {
+    val loggerInClass = logger()
+    val logPropertyInClass = log
+
+    companion object {
+        val loggerInCompanion = logger()
+        val logPropertyInCompanion = log
+    }
+}
+
+class TestClass02 {
+    val loggerInClass = logger()
+    val logPropertyInClass = log
+
+    companion object {
+        val loggerInCompanion = logger()
+        val logPropertyInCompanion = log
+    }
+}
+
+class KotlinLoggingExtensionTest {
+    private val loggerInTester = logger()
+    private val logPropertyInTester = log
+
+    @Test
+    fun testLoggerName() {
+        val loggerNameTesterClass = "mu.KotlinLoggingExtensionTest"
+        Assert.assertEquals(loggerNameTesterClass, loggerInTester.name)
+        Assert.assertEquals(loggerNameTesterClass, logPropertyInTester.name)
+        Assert.assertEquals(loggerNameTesterClass, log.name)
+
+        val loggerNameTestClass01 = "mu.TestClass01"
+        val instance01 = TestClass01()
+        Assert.assertEquals(loggerNameTestClass01, instance01.loggerInClass.name)
+        Assert.assertEquals(loggerNameTestClass01, instance01.logPropertyInClass.name)
+        Assert.assertEquals(loggerNameTestClass01, instance01.log.name)
+        Assert.assertEquals(loggerNameTestClass01, TestClass01.loggerInCompanion.name)
+        Assert.assertEquals(loggerNameTestClass01, TestClass01.logPropertyInCompanion.name)
+        Assert.assertEquals(loggerNameTestClass01, TestClass01.log.name)
+
+        val loggerNameTestClass02 = "mu.TestClass02"
+        val instance02 = TestClass02()
+        Assert.assertEquals(loggerNameTestClass02, instance02.loggerInClass.name)
+        Assert.assertEquals(loggerNameTestClass02, instance02.logPropertyInClass.name)
+        Assert.assertEquals(loggerNameTestClass02, instance02.log.name)
+        Assert.assertEquals(loggerNameTestClass02, TestClass02.loggerInCompanion.name)
+        Assert.assertEquals(loggerNameTestClass02, TestClass02.logPropertyInCompanion.name)
+        Assert.assertEquals(loggerNameTestClass02, TestClass02.log.name)
+    }
+}


### PR DESCRIPTION
this PR fix issue #77

change list:
add extension function and extension property for getting logger, to simplify the way how to define logger

with the help of this new extension property `T.log`, we can use `log` in any class, without calling the logger initialization code.

Before:
we need this logger initialization code:
`private val logger = KotlinLogging.logger {}`
before we can output log message

After this change, we can call
```
log.debug { "some message" }
```

without the logger initialization code.

for a large project, there could be many many classes, so this new extension property can save much of the duplicated code



