### PR TITLE
Provide for nullable in entry and rename exit argument

### DIFF
--- a/src/commonMain/kotlin/mu/KLogger.kt
+++ b/src/commonMain/kotlin/mu/KLogger.kt
@@ -105,7 +105,7 @@ expect interface KLogger {
     /**
      * Add a log message with all the supplied parameters along with method name
      */
-    fun entry(vararg argArray: Any)
+    fun entry(vararg argArray: Any?)
 
     /**
      * Add log message indicating exit of a method
@@ -115,7 +115,7 @@ expect interface KLogger {
     /**
      * Add a log message with the return value of a method
      */
-    fun <T> exit(retval: T): T where T : Any?
+    fun <T> exit(result: T): T where T : Any?
 
     /**
      * Add a log message indicating an exception will be thrown along with the stack trace.

--- a/src/jsMain/kotlin/mu/KLogger.kt
+++ b/src/jsMain/kotlin/mu/KLogger.kt
@@ -105,7 +105,7 @@ actual interface KLogger {
     /**
      * Add a log message with all the supplied parameters along with method name
      */
-    actual fun entry(vararg argArray: Any)
+    actual fun entry(vararg argArray: Any?)
 
     /**
      * Add log message indicating exit of a method
@@ -115,7 +115,7 @@ actual interface KLogger {
     /**
      * Add a log message with the return value of a method
      */
-    actual fun <T> exit(retval: T): T where T : Any?
+    actual fun <T> exit(result: T): T where T : Any?
 
     /**
      * Add a log message indicating an exception will be thrown along with the stack trace.

--- a/src/jsMain/kotlin/mu/internal/KLoggerJS.kt
+++ b/src/jsMain/kotlin/mu/internal/KLoggerJS.kt
@@ -90,7 +90,7 @@ internal class KLoggerJS(
         }
     }
 
-    override fun entry(vararg argArray: Any) {
+    override fun entry(vararg argArray: Any?) {
         TRACE.logIfEnabled({ "entry($argArray)" }, APPENDER::trace)
     }
 
@@ -98,9 +98,9 @@ internal class KLoggerJS(
         TRACE.logIfEnabled({ "exit()" }, APPENDER::trace)
     }
 
-    override fun <T : Any?> exit(retval: T): T {
-        TRACE.logIfEnabled({ "exit($retval)" }, APPENDER::trace)
-        return retval
+    override fun <T : Any?> exit(result: T): T {
+        TRACE.logIfEnabled({ "exit($result)" }, APPENDER::trace)
+        return result
     }
 
     override fun <T : Throwable> throwing(throwable: T): T {

--- a/src/jvmMain/kotlin/mu/KLogger.kt
+++ b/src/jvmMain/kotlin/mu/KLogger.kt
@@ -117,7 +117,7 @@ actual interface KLogger : Logger {
     /**
      * Add a log message with all the supplied parameters along with method name
      */
-    actual fun entry(vararg argArray: Any)
+    actual fun entry(vararg argArray: Any?)
 
     /**
      * Add log message indicating exit of a method
@@ -127,7 +127,7 @@ actual interface KLogger : Logger {
     /**
      * Add a log message with the return value of a method
      */
-    actual fun <T> exit(retval: T): T where T : Any?
+    actual fun <T> exit(result: T): T where T : Any?
 
     /**
      * Add a log message indicating an exception will be thrown along with the stack trace.

--- a/src/jvmMain/kotlin/mu/internal/LocationAwareKLogger.kt
+++ b/src/jvmMain/kotlin/mu/internal/LocationAwareKLogger.kt
@@ -575,7 +575,7 @@ internal class LocationAwareKLogger(override val underlyingLogger: LocationAware
         }
     }
 
-    override fun entry(vararg argArray: Any) {
+    override fun entry(vararg argArray: Any?) {
         if (underlyingLogger.isTraceEnabled(ENTRY)) {
             val tp = MessageFormatter.arrayFormat(buildMessagePattern(argArray.size), argArray)
             underlyingLogger.log(ENTRY, fqcn, LocationAwareLogger.TRACE_INT, tp.message, null, null);
@@ -588,14 +588,14 @@ internal class LocationAwareKLogger(override val underlyingLogger: LocationAware
         }
     }
 
-    override fun <T : Any?> exit(retval: T): T {
+    override fun <T : Any?> exit(result: T): T {
         if (underlyingLogger.isTraceEnabled(EXIT)) {
-            val tp = MessageFormatter.format(EXITMESSAGE, retval)
+            val tp = MessageFormatter.format(EXITMESSAGE, result)
             underlyingLogger.log(
-                EXIT, fqcn, LocationAwareLogger.TRACE_INT, tp.message, arrayOf<Any?>(retval), tp.throwable
+                EXIT, fqcn, LocationAwareLogger.TRACE_INT, tp.message, arrayOf<Any?>(result), tp.throwable
             )
         }
-        return retval
+        return result
     }
 
     override fun <T : Throwable> throwing(throwable: T): T {

--- a/src/jvmMain/kotlin/mu/internal/LocationIgnorantKLogger.kt
+++ b/src/jvmMain/kotlin/mu/internal/LocationIgnorantKLogger.kt
@@ -152,7 +152,7 @@ internal class LocationIgnorantKLogger(override val underlyingLogger: Logger) : 
         if (isErrorEnabled) error(marker, msg.toStringSafe(), t)
     }
 
-    override inline fun entry(vararg argArray: Any) {
+    override inline fun entry(vararg argArray: Any?) {
         if (underlyingLogger.isTraceEnabled) {
             underlyingLogger.trace("entry({})", argArray)
         }
@@ -164,11 +164,11 @@ internal class LocationIgnorantKLogger(override val underlyingLogger: Logger) : 
         }
     }
 
-    override inline fun <T : Any?> exit(retval: T): T {
+    override inline fun <T : Any?> exit(result: T): T {
         if (underlyingLogger.isTraceEnabled) {
-            underlyingLogger.trace("exit({}}", retval)
+            underlyingLogger.trace("exit({}}", result)
         }
-        return retval
+        return result
     }
 
     override inline fun <T : Throwable> throwing(throwable: T): T {

--- a/src/jvmTest/kotlin/mu/ClassWithLoggingForLocationTesting.kt
+++ b/src/jvmTest/kotlin/mu/ClassWithLoggingForLocationTesting.kt
@@ -21,7 +21,7 @@ class ClassWithLoggingForLocationTesting {
         return logger.exit(2 to 1)
     }
 
-    fun logExit(): Pair<Int, Int>? {
+    fun logExitOpt(): Pair<Int, Int>? {
         logger.entry(1, 2)
         logger.info("log entry body")
         return logger.exit(null)

--- a/src/jvmTest/kotlin/mu/LoggingWithLocationTest.kt
+++ b/src/jvmTest/kotlin/mu/LoggingWithLocationTest.kt
@@ -49,7 +49,7 @@ class LoggingWithLocationTest {
     }
 
     @Test
-    fun testNullLoggingWithLocationEntry() {
+    fun testNullLoggingWithLocationEntryExit() {
         ClassWithLoggingForLocationTesting().logEntry()
         Assert.assertEquals(
             "TRACE ClassWithLoggingForLocationTesting.logEntry(19) -  entry with (1, 2)" + System.lineSeparator() + "INFO " + "ClassWithLoggingForLocationTesting.logEntry(20) - log entry body" + System.lineSeparator() + "TRACE " + "ClassWithLoggingForLocationTesting.logEntry(21) - exit with ((2, 1))",
@@ -58,10 +58,12 @@ class LoggingWithLocationTest {
     }
 
     @Test
-    fun testNullLoggingWithLocationExit() {
-        ClassWithLoggingForLocationTesting().logExit()
+    fun testNullLoggingWithLocationEntryExitOpt() {
+        ClassWithLoggingForLocationTesting().logExitOpt()
         Assert.assertEquals(
-            "TRACE ClassWithLoggingForLocationTesting.logExit(25) -  entry with (1, 2)" + System.lineSeparator() + "INFO ClassWithLoggingForLocationTesting.logExit(26) - log entry body" + System.lineSeparator() + "TRACE ClassWithLoggingForLocationTesting.logExit(27) - exit with (null)",
+            "TRACE ClassWithLoggingForLocationTesting.logExitOpt(25) -  entry with (1, 2)" + System.lineSeparator() +
+                "INFO ClassWithLoggingForLocationTesting.logExitOpt(26) - log entry body" + System.lineSeparator() +
+                "TRACE ClassWithLoggingForLocationTesting.logExitOpt(27) - exit with (null)",
             appenderWithWriter.writer.toString().trim()
         )
     }


### PR DESCRIPTION
The type for entry is `vararg Any` and should be `vararg Any?` 
The name for exit was `retval` and `result` will  be better.
