### PR TITLE
Upgrade to Kotlin 1.4-M1 test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ fabric.properties
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+gradle.properties
+gradle.properties.tmp
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,10 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import java.util.Date
 
 plugins {
-    kotlin("multiplatform") version "1.3.70"
+    kotlin("multiplatform") version "1.4-M1"
     id("com.jfrog.bintray") version "1.8.4"
     id("org.jetbrains.dokka") version "0.10.0"
     `maven-publish`
-    `java-library`
 }
 
 buildscript {
@@ -14,14 +13,13 @@ buildscript {
 }
 
 group = "io.github.microutils"
-version = "1.6.27"
+version = "1.8.0-SNAPSHOT"
 
 repositories {
+    maven { setUrl("https://dl.bintray.com/kotlin/kotlin-eap") }
     mavenCentral()
     jcenter()
 }
-
-
 
 tasks {
     register<Jar>("javadocJar") {
@@ -33,18 +31,27 @@ tasks {
     dokka {
         outputFormat = "javadoc"
         outputDirectory = "$buildDir/dokka"
-
     }
 }
 
 kotlin {
+/*
     metadata {
         mavenPublication {
             // make a name of an artifact backward-compatible, default "-metadata"
-            artifactId = "${rootProject.name}-common"
+            //artifactId = "${rootProject.name}-common"
         }
     }
+*/
     jvm {
+        compilations.named("main") {
+            // kotlin compiler compatibility options
+            kotlinOptions {
+                apiVersion = "1.2"
+                languageVersion = "1.2"
+            }
+        }
+/*
         compilations.named("main") {
             // kotlin compiler compatibility options
             kotlinOptions {
@@ -54,10 +61,13 @@ kotlin {
         }
         mavenPublication {
             // make a name of jvm artifact backward-compatible, default "-jvm"
-            artifactId = rootProject.name
+            //artifactId = rootProject.name
         }
+*/
     }
     js {
+        produceKotlinLibrary()
+/*
         compilations.named("main") {
             kotlinOptions {
                 metaInfo = true
@@ -66,26 +76,27 @@ kotlin {
                 moduleKind = "umd"
             }
         }
+*/
     }
     sourceSets {
-        commonMain {
+        val commonMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-common"))
+                implementation(kotlin("stdlib"))
             }
         }
-        commonTest {
+        val commonTest by getting  {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
         }
-        named("jvmMain") {
+        val jvmMain by getting {
             dependencies {
                 implementation(kotlin("stdlib"))
                 api("org.slf4j:slf4j-api:${extra["sl4j_version"]}")
             }
         }
-        named("jvmTest") {
+        val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit"))
@@ -96,12 +107,12 @@ kotlin {
                 implementation("org.apache.logging.log4j:log4j-slf4j-impl:${extra["log4j_version"]}")
             }
         }
-        named("jsMain") {
+        val jsMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-js"))
             }
         }
-        named("jsTest") {
+        val jsTest by getting {
             dependencies {
                 implementation(kotlin("test-js"))
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,6 +123,38 @@ kotlin {
 }
 
 publishing {
+Add     repositories {
+        maven {
+            name = "releases"
+            // change to point to your repo, e.g. http://my.org/repo
+            url = uri("http://nexus.astraeus.nl/nexus/content/repositories/releases")
+            credentials {
+                val nexusUsername: String by project
+                val nexusPassword: String by project
+
+                username = nexusUsername
+                password = nexusPassword
+            }
+        }
+        maven {
+            name = "snapshots"
+            // change to point to your repo, e.g. http://my.org/repo
+            url = uri("http://nexus.astraeus.nl/nexus/content/repositories/snapshots")
+            credentials {
+                val nexusUsername: String by project
+                val nexusPassword: String by project
+
+                username = nexusUsername
+                password = nexusPassword
+            }
+        }
+    }
+    publications {
+        val kotlinMultiplatform by getting {
+            //artifactId = "kotlin-css-generator"
+        }
+    }
+
     publications.withType<MavenPublication> {
         pom {
             name.set("kotlin-logging")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,7 +123,7 @@ kotlin {
 }
 
 publishing {
-Add     repositories {
+     repositories {
         maven {
             name = "releases"
             // change to point to your repo, e.g. http://my.org/repo

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import java.util.Date
 
 plugins {
-    kotlin("multiplatform") version "1.4-M1"
+    kotlin("multiplatform") version "1.4-M2"
     id("com.jfrog.bintray") version "1.8.4"
     id("org.jetbrains.dokka") version "0.10.0"
     `maven-publish`
@@ -13,7 +13,7 @@ buildscript {
 }
 
 group = "io.github.microutils"
-version = "1.8.0-SNAPSHOT"
+version = "1.8.1-SNAPSHOT"
 
 repositories {
     maven { setUrl("https://dl.bintray.com/kotlin/kotlin-eap") }
@@ -65,8 +65,10 @@ kotlin {
         }
 */
     }
-    js {
-        produceKotlinLibrary()
+    js(BOTH) {
+        //produceKotlinLibrary()
+        browser()
+
 /*
         compilations.named("main") {
             kotlinOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.code.style=official
+kotlin.js.compiler=both

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,0 @@
-kotlin.code.style=official
-kotlin.js.compiler=both

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,22 @@
+pluginManagement {
+    repositories {
+        maven { setUrl("https://dl.bintray.com/kotlin/kotlin-eap") }
+
+        mavenCentral()
+
+        maven { setUrl("https://plugins.gradle.org/m2/") }
+    }
+}
+
 rootProject.name = "kotlin-logging"
 
 enableFeaturePreview("GRADLE_METADATA")
 
 buildscript {
     repositories {
+        maven { setUrl("https://dl.bintray.com/kotlin/kotlin-eap") }
         mavenCentral()
         jcenter()
     }
 }
+

--- a/src/jvmTest/kotlin/mu/LoggingTest.kt
+++ b/src/jvmTest/kotlin/mu/LoggingTest.kt
@@ -209,7 +209,7 @@ class LoggingTest {
         LambdaRaisesError().test()
         appenderWithWriter.writer.flush()
         Assert.assertEquals(
-            "INFO  mu.LambdaRaisesError  - Log message invocation failed: kotlin.KotlinNullPointerException",
+            "INFO  mu.LambdaRaisesError  - Log message invocation failed: java.lang.NullPointerException",
             appenderWithWriter.writer.toString().trim()
         )
     }


### PR DESCRIPTION
This is a test/example to see how easy it is to create a library with the new IR format introduced in Koltin 1.4-M1.

This works for my scenario, some remarks:

- I needed to upgrade kotlin version to 1.2, compiler no longer supports 1.1
- Used the default naming of targets to simplify testing, backwards compatible naming probably still works fine
