### PR TITLE
ability to create custom logger factories to make non-SLF4J implementations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
 }
 
 group = "io.github.microutils"
-version = "1.6.27"
+version = "2.0"
 
 repositories {
     mavenCentral()

--- a/src/commonMain/kotlin/mu/KLogger.kt
+++ b/src/commonMain/kotlin/mu/KLogger.kt
@@ -3,6 +3,11 @@ package mu
 expect interface KLogger {
 
     /**
+     * Logger External Name
+     */
+    val name: String
+
+    /**
      * Lazy add a log message if isTraceEnabled is true
      */
     fun trace(msg: () -> Any?)

--- a/src/commonMain/kotlin/mu/KLoggerFactory.kt
+++ b/src/commonMain/kotlin/mu/KLoggerFactory.kt
@@ -1,0 +1,9 @@
+package mu
+
+/**
+ * Factory for creating KLoggers
+ */
+expect interface KLoggerFactory {
+    fun logger(name: String): KLogger
+    fun logger(func: () -> Unit): KLogger
+}

--- a/src/commonMain/kotlin/mu/KotlinLogging.kt
+++ b/src/commonMain/kotlin/mu/KotlinLogging.kt
@@ -11,4 +11,7 @@ expect object KotlinLogging {
     fun logger(func: () -> Unit): KLogger
 
     fun logger(name: String): KLogger
+
+    var kLoggerFactory: KLoggerFactory
 }
+

--- a/src/commonMain/kotlin/mu/KotlinLoggingExtensions.kt
+++ b/src/commonMain/kotlin/mu/KotlinLoggingExtensions.kt
@@ -1,0 +1,8 @@
+package mu
+
+import mu.internal.KLoggerFactoryDefault
+
+/**
+ * Default Logger Factory reference
+ */
+val defaultLoggerFactory: KLoggerFactory get() = KLoggerFactoryDefault

--- a/src/commonMain/kotlin/mu/internal/KLoggerFactoryDefault.kt
+++ b/src/commonMain/kotlin/mu/internal/KLoggerFactoryDefault.kt
@@ -1,0 +1,21 @@
+package mu.internal
+
+import mu.KLogger
+import mu.KLoggerFactory
+
+/**
+ * factory methods to obtain a [KLogger]
+ */
+@Suppress("NOTHING_TO_INLINE")
+internal expect object KLoggerFactoryDefault : KLoggerFactory {
+    /**
+     * get logger by explicit name
+     */
+    override fun logger(name: String): KLogger
+
+    /**
+     * get logger for the method, assuming it was declared at the logger file/class
+     */
+    override fun logger(func: () -> Unit): KLogger
+
+}

--- a/src/jsMain/kotlin/mu/KLogger.kt
+++ b/src/jsMain/kotlin/mu/KLogger.kt
@@ -3,6 +3,11 @@ package mu
 actual interface KLogger {
 
     /**
+     * Logger Name
+     */
+    actual val name: String
+
+    /**
      * Lazy add a log message if isTraceEnabled is true
      */
     actual fun trace(msg: () -> Any?)

--- a/src/jsMain/kotlin/mu/KLoggerFactory.kt
+++ b/src/jsMain/kotlin/mu/KLoggerFactory.kt
@@ -1,0 +1,6 @@
+package mu
+
+actual interface KLoggerFactory {
+    actual fun logger(name: String): KLogger
+    actual fun logger(func: () -> Unit): KLogger
+}

--- a/src/jsMain/kotlin/mu/KotlinLogging.kt
+++ b/src/jsMain/kotlin/mu/KotlinLogging.kt
@@ -1,6 +1,6 @@
 package mu
 
-import mu.internal.KLoggerJS
+import mu.internal.KLoggerFactoryDefault
 
 
 actual object KotlinLogging {
@@ -10,7 +10,8 @@ actual object KotlinLogging {
      * val logger = KotlinLogging.logger {}
      * ```
      */
-    actual fun logger(func: () -> Unit): KLogger = KLoggerJS(func::class.js.name)
+    actual fun logger(func: () -> Unit): KLogger = kLoggerFactory.logger(func)
 
-    actual fun logger(name: String): KLogger = KLoggerJS(name)
+    actual fun logger(name: String): KLogger = kLoggerFactory.logger(name)
+    actual var kLoggerFactory: KLoggerFactory = KLoggerFactoryDefault
 }

--- a/src/jsMain/kotlin/mu/internal/KLoggerFactoryDefault.kt
+++ b/src/jsMain/kotlin/mu/internal/KLoggerFactoryDefault.kt
@@ -1,0 +1,15 @@
+package mu.internal
+
+import mu.KLogger
+import mu.KLoggerFactory
+
+/**
+ * factory methods to obtain a [KLogger]
+ */
+@Suppress("NOTHING_TO_INLINE")
+internal actual object KLoggerFactoryDefault : KLoggerFactory {
+    actual override fun logger(name: String): KLogger = KLoggerJS(name)
+
+    actual override fun logger(func: () -> Unit): KLogger = KLoggerJS(func::class.js.name)
+
+}

--- a/src/jsMain/kotlin/mu/internal/KLoggerJS.kt
+++ b/src/jsMain/kotlin/mu/internal/KLoggerJS.kt
@@ -13,7 +13,7 @@ import mu.Marker
 import mu.isLoggingEnabled
 
 internal class KLoggerJS(
-    private val loggerName: String
+    override val name: String
 ) : KLogger {
 
     override fun trace(msg: () -> Any?) = TRACE.logIfEnabled(msg, APPENDER::trace)
@@ -63,19 +63,19 @@ internal class KLoggerJS(
 
     private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(FORMATTER.formatMessage(this, loggerName, msg))
+            logFunction(FORMATTER.formatMessage(this, name, msg))
         }
     }
 
     private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, t: Throwable?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(FORMATTER.formatMessage(this, loggerName, t, msg))
+            logFunction(FORMATTER.formatMessage(this, name, t, msg))
         }
     }
 
     private fun KotlinLoggingLevel.logIfEnabled(marker: Marker?, msg: () -> Any?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(FORMATTER.formatMessage(this, loggerName, marker, msg))
+            logFunction(FORMATTER.formatMessage(this, name, marker, msg))
         }
     }
 
@@ -86,7 +86,7 @@ internal class KLoggerJS(
         logFunction: (Any?) -> Unit
     ) {
         if (isLoggingEnabled()) {
-            logFunction(FORMATTER.formatMessage(this, loggerName, marker, t, msg))
+            logFunction(FORMATTER.formatMessage(this, name, marker, t, msg))
         }
     }
 

--- a/src/jvmMain/kotlin/mu/KLogger.kt
+++ b/src/jvmMain/kotlin/mu/KLogger.kt
@@ -9,12 +9,12 @@ import org.slf4j.Logger
  * logger.info{"this is $lazy evaluated string"}
  *```
  */
-actual interface KLogger : Logger {
+actual interface KLogger {
 
     /**
-     * The actual logger executing logging
+     * Logger Name
      */
-    val underlyingLogger: Logger
+    actual val name: String
 
     /**
      * Lazy add a log message if isTraceEnabled is true

--- a/src/jvmMain/kotlin/mu/KLoggerFactory.kt
+++ b/src/jvmMain/kotlin/mu/KLoggerFactory.kt
@@ -1,0 +1,11 @@
+package mu
+
+actual interface KLoggerFactory {
+    actual fun logger(name: String): KLogger
+    actual fun logger(func: () -> Unit): KLogger
+
+    /**
+     * Factory function for getting
+     */
+    fun logger(loggable: KLoggable): KLogger
+}

--- a/src/jvmMain/kotlin/mu/KLogging.kt
+++ b/src/jvmMain/kotlin/mu/KLogging.kt
@@ -1,6 +1,7 @@
 package mu
 
-import mu.internal.KLoggerFactory
+import mu.internal.KLoggerFactoryDefault
+import mu.internal.KLoggerFactoryDefault.logger
 
 /**
  * A class with logging capabilities
@@ -37,16 +38,18 @@ interface KLoggable {
      */
     val logger: KLogger
 
-    /**
-     * get logger for the class
-     */
-    fun logger(): KLogger = KLoggerFactory.logger(this)
-
-    /**
-     * get logger by explicit name
-     */
-    fun logger(name: String): KLogger = KLoggerFactory.logger(name)
 }
+
+/**
+ * get logger by explicit name
+ */
+fun KLoggable.logger(name: String): KLogger = KotlinLogging.logger(name)
+
+
+/**
+ * get logger for the class
+ */
+fun KLoggable.logger(): KLogger = KotlinLogging.logger(this)
 
 
 

--- a/src/jvmMain/kotlin/mu/KotlinLogging.kt
+++ b/src/jvmMain/kotlin/mu/KotlinLogging.kt
@@ -1,6 +1,6 @@
 package mu
 
-import mu.internal.KLoggerFactory
+import mu.internal.KLoggerFactoryDefault
 import org.slf4j.Logger
 
 
@@ -11,11 +11,15 @@ actual object KotlinLogging {
      * val logger = KotlinLogging.logger {}
      * ```
      */
-    actual fun logger(func: () -> Unit): KLogger = KLoggerFactory.logger(func)
+    actual fun logger(func: () -> Unit): KLogger = kLoggerFactory.logger(func)
 
-    actual fun logger(name: String): KLogger = KLoggerFactory.logger(name)
+    actual fun logger(name: String): KLogger = kLoggerFactory.logger(name)
 
-    fun logger(underlyingLogger: Logger) = KLoggerFactory.wrapJLogger(underlyingLogger)
+    fun logger(underlyingLogger: Logger) = KLoggerFactoryDefault.wrapJLogger(underlyingLogger)
+
+    fun logger(kLoggable: KLoggable): KLogger = kLoggerFactory.logger(kLoggable)
+
+    actual var kLoggerFactory: KLoggerFactory = KLoggerFactoryDefault
 }
 
 fun Logger.toKLogger() = KotlinLogging.logger(this)

--- a/src/jvmMain/kotlin/mu/internal/KLoggerFactoryDefault.kt
+++ b/src/jvmMain/kotlin/mu/internal/KLoggerFactoryDefault.kt
@@ -2,6 +2,7 @@ package mu.internal
 
 import mu.KLoggable
 import mu.KLogger
+import mu.KLoggerFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.spi.LocationAwareLogger
@@ -10,23 +11,23 @@ import org.slf4j.spi.LocationAwareLogger
  * factory methods to obtain a [Logger]
  */
 @Suppress("NOTHING_TO_INLINE")
-internal object KLoggerFactory {
+internal actual object KLoggerFactoryDefault : KLoggerFactory {
 
     /**
      * get logger for the class
      */
-    internal inline fun logger(loggable: KLoggable): KLogger =
+    override fun logger(loggable: KLoggable): KLogger =
         logger(KLoggerNameResolver.name(loggable.javaClass))
 
     /**
      * get logger by explicit name
      */
-    internal inline fun logger(name: String): KLogger = wrapJLogger(jLogger(name))
+    actual override fun logger(name: String): KLogger = wrapJLogger(jLogger(name))
 
     /**
      * get logger for the method, assuming it was declared at the logger file/class
      */
-    internal inline fun logger(noinline func: () -> Unit): KLogger =
+     actual override fun logger(func: () -> Unit): KLogger =
         logger(KLoggerNameResolver.name(func))
 
     /**

--- a/src/jvmMain/kotlin/mu/internal/LocationAwareKLogger.kt
+++ b/src/jvmMain/kotlin/mu/internal/LocationAwareKLogger.kt
@@ -11,8 +11,7 @@ import org.slf4j.spi.LocationAwareLogger
  * A class wrapping a [LocationAwareLogger] instance preserving
  * location information with the correct fully qualified class name.
  */
-internal class LocationAwareKLogger(override val underlyingLogger: LocationAwareLogger) : KLogger,
-                                                                                          Logger by underlyingLogger {
+internal class LocationAwareKLogger(private val underlyingLogger: LocationAwareLogger) : KLogger {
 
     private val fqcn: String = LocationAwareKLogger::class.java.name
     private val ENTRY = KMarkerFactory.getMarker("ENTRY")
@@ -23,550 +22,253 @@ internal class LocationAwareKLogger(override val underlyingLogger: LocationAware
     private val EXITONLY = "exit"
     private val EXITMESSAGE = "exit with ({})"
 
-    override fun trace(msg: String?) {
-        if (!underlyingLogger.isTraceEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.TRACE_INT, msg, null, null
-        )
-    }
-
-    override fun trace(format: String?, arg: Any?) {
-        if (!underlyingLogger.isTraceEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, arrayOf(arg), null
-        )
-    }
-
-    override fun trace(format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isTraceEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun trace(format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isTraceEnabled) return
-
-        val formattedMessage = MessageFormatter.arrayFormat(format, argArray).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, argArray, null
-        )
-    }
-
-    override fun trace(msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isTraceEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.TRACE_INT, msg, null, t
-        )
-    }
-
-    override fun trace(marker: Marker?, msg: String?) {
-        if (!underlyingLogger.isTraceEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.TRACE_INT, msg, null, null
-        )
-    }
-
-    override fun trace(marker: Marker?, format: String?, arg: Any?) {
-        if (!underlyingLogger.isTraceEnabled) return
-        val formattedMessage = MessageFormatter.format(format, arg).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, arrayOf(arg), null
-        )
-    }
-
-    override fun trace(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isTraceEnabled) return
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun trace(marker: Marker?, format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isTraceEnabled) return
-        val formattedMessage = MessageFormatter.arrayFormat(format, argArray).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, argArray, null
-        )
-    }
-
-    override fun trace(marker: Marker?, msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isTraceEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.TRACE_INT, msg, null, t
-        )
-    }
-
-    override fun debug(msg: String?) {
-        if (!underlyingLogger.isDebugEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.DEBUG_INT, msg, null, null
-        )
-    }
-
-    override fun debug(format: String?, arg: Any?) {
-        if (!underlyingLogger.isDebugEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.DEBUG_INT, formattedMessage, arrayOf(arg), null
-        )
-    }
-
-    override fun debug(format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isDebugEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.DEBUG_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun debug(format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isDebugEnabled) return
-
-        val ft = MessageFormatter.arrayFormat(format, argArray)
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.DEBUG_INT, ft.message, ft.argArray, ft.throwable
-        )
-    }
-
-    override fun debug(msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isDebugEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.DEBUG_INT, msg, null, t
-        )
-    }
-
-    override fun debug(marker: Marker?, msg: String?) {
-        if (!underlyingLogger.isDebugEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.DEBUG_INT, msg, null, null
-        )
-    }
-
-    override fun debug(marker: Marker?, format: String?, arg: Any?) {
-        if (!underlyingLogger.isDebugEnabled) return
-        val ft = MessageFormatter.format(format, arg)
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.DEBUG_INT, ft.message, ft.argArray, ft.throwable
-        )
-    }
-
-    override fun debug(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isDebugEnabled) return
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.DEBUG_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun debug(marker: Marker?, format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isDebugEnabled) return
-
-        val ft = MessageFormatter.arrayFormat(format, argArray)
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.DEBUG_INT, ft.message, argArray, ft.throwable
-        )
-    }
-
-    override fun debug(marker: Marker?, msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isDebugEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.DEBUG_INT, msg, null, t
-        )
-    }
-
-    override fun info(msg: String?) {
-        if (!underlyingLogger.isInfoEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.INFO_INT, msg, null, null
-        )
-    }
-
-    override fun info(format: String?, arg: Any?) {
-        if (!underlyingLogger.isInfoEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, arrayOf(arg), null
-        )
-    }
-
-    override fun info(format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isInfoEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun info(format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isInfoEnabled) return
-
-        val formattedMessage = MessageFormatter.arrayFormat(format, argArray).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, argArray, null
-        )
-    }
-
-    override fun info(msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isInfoEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.INFO_INT, msg, null, t
-        )
-    }
-
-    override fun info(marker: Marker?, msg: String?) {
-        if (!underlyingLogger.isInfoEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.INFO_INT, msg, null, null
-        )
-    }
-
-    override fun info(marker: Marker?, format: String?, arg: Any?) {
-        if (!underlyingLogger.isInfoEnabled) return
-        val formattedMessage = MessageFormatter.format(format, arg).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, arrayOf(arg), null
-        )
-    }
-
-    override fun info(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isInfoEnabled) return
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun info(marker: Marker?, format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isInfoEnabled) return
-        val formattedMessage = MessageFormatter.arrayFormat(format, argArray).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, argArray, null
-        )
-    }
-
-    override fun info(marker: Marker?, msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isInfoEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.INFO_INT, msg, null, t
-        )
-    }
-
-    override fun warn(msg: String?) {
-        if (!underlyingLogger.isWarnEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.WARN_INT, msg, null, null
-        )
-    }
-
-    override fun warn(format: String?, arg: Any?) {
-        if (!underlyingLogger.isWarnEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, arrayOf(arg), null
-        )
-    }
-
-    override fun warn(format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isWarnEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun warn(format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isWarnEnabled) return
-
-        val formattedMessage = MessageFormatter.arrayFormat(format, argArray).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, argArray, null
-        )
-    }
-
-    override fun warn(msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isWarnEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.WARN_INT, msg, null, t
-        )
-    }
-
-    override fun warn(marker: Marker?, msg: String?) {
-        if (!underlyingLogger.isWarnEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.WARN_INT, msg, null, null
-        )
-    }
-
-    override fun warn(marker: Marker?, format: String?, arg: Any?) {
-        if (!underlyingLogger.isWarnEnabled) return
-        val formattedMessage = MessageFormatter.format(format, arg).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, arrayOf(arg), null
-        )
-    }
-
-    override fun warn(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isWarnEnabled) return
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun warn(marker: Marker?, format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isWarnEnabled) return
-        val formattedMessage = MessageFormatter.arrayFormat(format, argArray).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, argArray, null
-        )
-    }
-
-    override fun warn(marker: Marker?, msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isWarnEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.WARN_INT, msg, null, t
-        )
-    }
-
-    override fun error(msg: String?) {
-        if (!underlyingLogger.isErrorEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.ERROR_INT, msg, null, null
-        )
-    }
-
-    override fun error(format: String?, arg: Any?) {
-        if (!underlyingLogger.isErrorEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, arrayOf(arg), null
-        )
-    }
-
-    override fun error(format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isErrorEnabled) return
-
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun error(format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isErrorEnabled) return
-
-        val formattedMessage = MessageFormatter.arrayFormat(format, argArray).message
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, argArray, null
-        )
-    }
-
-    override fun error(msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isErrorEnabled) return
-
-        underlyingLogger.log(
-            null, fqcn, LocationAwareLogger.ERROR_INT, msg, null, t
-        )
-    }
-
-    override fun error(marker: Marker?, msg: String?) {
-        if (!underlyingLogger.isErrorEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.ERROR_INT, msg, null, null
-        )
-    }
-
-    override fun error(marker: Marker?, format: String?, arg: Any?) {
-        if (!underlyingLogger.isErrorEnabled) return
-        val formattedMessage = MessageFormatter.format(format, arg).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, arrayOf(arg), null
-        )
-    }
-
-    override fun error(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) {
-        if (!underlyingLogger.isErrorEnabled) return
-        val formattedMessage = MessageFormatter.format(format, arg1, arg2).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, arrayOf(arg1, arg2), null
-        )
-    }
-
-    override fun error(marker: Marker?, format: String?, argArray: Array<Any?>) {
-        if (!underlyingLogger.isErrorEnabled) return
-        val formattedMessage = MessageFormatter.arrayFormat(format, argArray).message
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, argArray, null
-        )
-    }
-
-    override fun error(marker: Marker?, msg: String?, t: Throwable?) {
-        if (!underlyingLogger.isErrorEnabled) return
-        underlyingLogger.log(
-            marker, fqcn, LocationAwareLogger.ERROR_INT, msg, null, t
-        )
-    }
+    override val name: String
+        get() = underlyingLogger.name
 
     /**
      * Lazy add a log message if isTraceEnabled is true
      */
     override fun trace(msg: () -> Any?) {
-        if (isTraceEnabled) trace(msg.toStringSafe())
+        if (underlyingLogger.isTraceEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.TRACE_INT,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message if isDebugEnabled is true
      */
     override fun debug(msg: () -> Any?) {
-        if (isDebugEnabled) debug(msg.toStringSafe())
+        if (underlyingLogger.isDebugEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.DEBUG_INT,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message if isInfoEnabled is true
      */
     override fun info(msg: () -> Any?) {
-        if (isInfoEnabled) info(msg.toStringSafe())
+        if (underlyingLogger.isInfoEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.INFO_INT,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message if isWarnEnabled is true
      */
     override fun warn(msg: () -> Any?) {
-        if (isWarnEnabled) warn(msg.toStringSafe())
+        if (underlyingLogger.isWarnEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.WARN_INT,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message if isErrorEnabled is true
      */
     override fun error(msg: () -> Any?) {
-        if (isErrorEnabled) error(msg.toStringSafe())
+        if (underlyingLogger.isErrorEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.ERROR_INT,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with throwable payload if isTraceEnabled is true
      */
     override fun trace(t: Throwable?, msg: () -> Any?) {
-        if (isTraceEnabled) trace(msg.toStringSafe(), t)
+        if (underlyingLogger.isTraceEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.TRACE_INT,
+                t = t,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with throwable payload if isDebugEnabled is true
      */
     override fun debug(t: Throwable?, msg: () -> Any?) {
-        if (isDebugEnabled) debug(msg.toStringSafe(), t)
+        if (underlyingLogger.isDebugEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.DEBUG_INT,
+                t = t,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with throwable payload if isInfoEnabled is true
      */
     override fun info(t: Throwable?, msg: () -> Any?) {
-        if (isInfoEnabled) info(msg.toStringSafe(), t)
+        if (underlyingLogger.isInfoEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.INFO_INT,
+                t = t,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with throwable payload if isWarnEnabled is true
      */
     override fun warn(t: Throwable?, msg: () -> Any?) {
-        if (isWarnEnabled) warn(msg.toStringSafe(), t)
+        if (underlyingLogger.isWarnEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.WARN_INT,
+                t = t,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with throwable payload if isErrorEnabled is true
      */
     override fun error(t: Throwable?, msg: () -> Any?) {
-        if (isErrorEnabled) error(msg.toStringSafe(), t)
+        if (underlyingLogger.isErrorEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.ERROR_INT,
+                t = t,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with a marker if isTraceEnabled is true
      */
     override fun trace(marker: Marker?, msg: () -> Any?) {
-        if (isTraceEnabled) trace(marker, msg.toStringSafe())
+        if (underlyingLogger.isTraceEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.TRACE_INT,
+                marker = marker,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with a marker if isDebugEnabled is true
      */
     override fun debug(marker: Marker?, msg: () -> Any?) {
-        if (isDebugEnabled) debug(marker, msg.toStringSafe())
+        if (underlyingLogger.isDebugEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.DEBUG_INT,
+                marker = marker,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with a marker if isInfoEnabled is true
      */
     override fun info(marker: Marker?, msg: () -> Any?) {
-        if (isInfoEnabled) info(marker, msg.toStringSafe())
+        if (underlyingLogger.isInfoEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.INFO_INT,
+                marker = marker,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with a marker if isWarnEnabled is true
      */
     override fun warn(marker: Marker?, msg: () -> Any?) {
-        if (isWarnEnabled) warn(marker, msg.toStringSafe())
+        if (underlyingLogger.isWarnEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.WARN_INT,
+                marker = marker,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with a marker if isErrorEnabled is true
      */
     override fun error(marker: Marker?, msg: () -> Any?) {
-        if (isErrorEnabled) error(marker, msg.toStringSafe())
+        if (underlyingLogger.isErrorEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.ERROR_INT,
+                marker = marker,
+                msg = msg
+            )
     }
 
     /**
      * Lazy add a log message with a marker and throwable payload if isTraceEnabled is true
      */
     override fun trace(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isTraceEnabled) trace(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isTraceEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.TRACE_INT,
+                marker = marker,
+                t = t,
+                msg = msg
+            )
     }
 
+    private inline fun logAt(logLevel: Int, marker: Marker? = null, t: Throwable? = null, msg: (() -> Any?)) {
+        underlyingLogger.log(
+            marker, fqcn, logLevel, msg.toStringSafe(), null, t
+        )
+    }
     /**
      * Lazy add a log message with a marker and throwable payload if isDebugEnabled is true
      */
     override fun debug(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isDebugEnabled) debug(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isDebugEnabled) {
+            logAt(
+                logLevel = LocationAwareLogger.DEBUG_INT,
+                marker = marker,
+                msg = msg,
+                t = t
+            )
+        }
     }
 
     /**
      * Lazy add a log message with a marker and throwable payload if isInfoEnabled is true
      */
     override fun info(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isInfoEnabled) info(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isInfoEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.INFO_INT,
+                marker = marker,
+                msg = msg,
+                t = t
+            )
     }
 
     /**
      * Lazy add a log message with a marker and throwable payload if isWarnEnabled is true
      */
     override fun warn(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isWarnEnabled) warn(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isWarnEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.WARN_INT,
+                marker = marker,
+                msg = msg,
+                t = t
+            )
     }
 
     /**
      * Lazy add a log message with a marker and throwable payload if isErrorEnabled is true
      */
     override fun error(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isErrorEnabled) error(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isErrorEnabled)
+            logAt(
+                logLevel = LocationAwareLogger.ERROR_INT,
+                marker = marker,
+                msg = msg,
+                t = t
+            )
     }
 
     override fun <T : Throwable> catching(throwable: T) {
@@ -578,7 +280,7 @@ internal class LocationAwareKLogger(override val underlyingLogger: LocationAware
     override fun entry(vararg argArray: Any?) {
         if (underlyingLogger.isTraceEnabled(ENTRY)) {
             val tp = MessageFormatter.arrayFormat(buildMessagePattern(argArray.size), argArray)
-            underlyingLogger.log(ENTRY, fqcn, LocationAwareLogger.TRACE_INT, tp.message, null, null);
+            underlyingLogger.log(ENTRY, fqcn, LocationAwareLogger.TRACE_INT, tp.message, null, null)
         }
     }
 

--- a/src/jvmMain/kotlin/mu/internal/LocationIgnorantKLogger.kt
+++ b/src/jvmMain/kotlin/mu/internal/LocationIgnorantKLogger.kt
@@ -12,146 +12,149 @@ import org.slf4j.Marker
  * the rest of the methods are delegated to [Logger]
  * Hence no implemented methods
  */
-internal class LocationIgnorantKLogger(override val underlyingLogger: Logger) : KLogger, Logger by underlyingLogger {
+internal class LocationIgnorantKLogger(private val underlyingLogger: Logger) : KLogger {
+
+    override val name: String
+        get() = underlyingLogger.name
 
     /**
      * Lazy add a log message if isTraceEnabled is true
      */
     override fun trace(msg: () -> Any?) {
-        if (isTraceEnabled) trace(msg.toStringSafe())
+        if (underlyingLogger.isTraceEnabled) underlyingLogger.trace(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isDebugEnabled is true
      */
     override fun debug(msg: () -> Any?) {
-        if (isDebugEnabled) debug(msg.toStringSafe())
+        if (underlyingLogger.isDebugEnabled) underlyingLogger.debug(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isInfoEnabled is true
      */
     override fun info(msg: () -> Any?) {
-        if (isInfoEnabled) info(msg.toStringSafe())
+        if (underlyingLogger.isInfoEnabled) underlyingLogger.info(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isWarnEnabled is true
      */
     override fun warn(msg: () -> Any?) {
-        if (isWarnEnabled) warn(msg.toStringSafe())
+        if (underlyingLogger.isWarnEnabled) underlyingLogger.warn(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message if isErrorEnabled is true
      */
     override fun error(msg: () -> Any?) {
-        if (isErrorEnabled) error(msg.toStringSafe())
+        if (underlyingLogger.isErrorEnabled) underlyingLogger.error(msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message with throwable payload if isTraceEnabled is true
      */
     override fun trace(t: Throwable?, msg: () -> Any?) {
-        if (isTraceEnabled) trace(msg.toStringSafe(), t)
+        if (underlyingLogger.isTraceEnabled) underlyingLogger.trace(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isDebugEnabled is true
      */
     override fun debug(t: Throwable?, msg: () -> Any?) {
-        if (isDebugEnabled) debug(msg.toStringSafe(), t)
+        if (underlyingLogger.isDebugEnabled) underlyingLogger.debug(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isInfoEnabled is true
      */
     override fun info(t: Throwable?, msg: () -> Any?) {
-        if (isInfoEnabled) info(msg.toStringSafe(), t)
+        if (underlyingLogger.isInfoEnabled) underlyingLogger.info(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isWarnEnabled is true
      */
     override fun warn(t: Throwable?, msg: () -> Any?) {
-        if (isWarnEnabled) warn(msg.toStringSafe(), t)
+        if (underlyingLogger.isWarnEnabled) underlyingLogger.warn(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with throwable payload if isErrorEnabled is true
      */
     override fun error(t: Throwable?, msg: () -> Any?) {
-        if (isErrorEnabled) error(msg.toStringSafe(), t)
+        if (underlyingLogger.isErrorEnabled) underlyingLogger.error(msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with a marker if isTraceEnabled is true
      */
     override fun trace(marker: Marker?, msg: () -> Any?) {
-        if (isTraceEnabled) trace(marker, msg.toStringSafe())
+        if (underlyingLogger.isTraceEnabled) underlyingLogger.trace(marker, msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message with a marker if isDebugEnabled is true
      */
     override fun debug(marker: Marker?, msg: () -> Any?) {
-        if (isDebugEnabled) debug(marker, msg.toStringSafe())
+        if (underlyingLogger.isDebugEnabled) underlyingLogger.debug(marker, msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message with a marker if isInfoEnabled is true
      */
     override fun info(marker: Marker?, msg: () -> Any?) {
-        if (isInfoEnabled) info(marker, msg.toStringSafe())
+        if (underlyingLogger.isInfoEnabled) underlyingLogger.info(marker, msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message with a marker if isWarnEnabled is true
      */
     override fun warn(marker: Marker?, msg: () -> Any?) {
-        if (isWarnEnabled) warn(marker, msg.toStringSafe())
+        if (underlyingLogger.isWarnEnabled) underlyingLogger.warn(marker, msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message with a marker if isErrorEnabled is true
      */
     override fun error(marker: Marker?, msg: () -> Any?) {
-        if (isErrorEnabled) error(marker, msg.toStringSafe())
+        if (underlyingLogger.isErrorEnabled) underlyingLogger.error(marker, msg.toStringSafe())
     }
 
     /**
      * Lazy add a log message with a marker and throwable payload if isTraceEnabled is true
      */
     override fun trace(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isTraceEnabled) trace(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isTraceEnabled) underlyingLogger.trace(marker, msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with a marker and throwable payload if isDebugEnabled is true
      */
     override fun debug(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isDebugEnabled) debug(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isDebugEnabled) underlyingLogger.debug(marker, msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with a marker and throwable payload if isInfoEnabled is true
      */
     override fun info(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isInfoEnabled) info(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isInfoEnabled) underlyingLogger.info(marker, msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with a marker and throwable payload if isWarnEnabled is true
      */
     override fun warn(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isWarnEnabled) warn(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isWarnEnabled) underlyingLogger.warn(marker, msg.toStringSafe(), t)
     }
 
     /**
      * Lazy add a log message with a marker and throwable payload if isErrorEnabled is true
      */
     override fun error(marker: Marker?, t: Throwable?, msg: () -> Any?) {
-        if (isErrorEnabled) error(marker, msg.toStringSafe(), t)
+        if (underlyingLogger.isErrorEnabled) underlyingLogger.error(marker, msg.toStringSafe(), t)
     }
 
     override inline fun entry(vararg argArray: Any?) {

--- a/src/jvmTest/kotlin/mu/ClassWithLoggingForLocationTesting.kt
+++ b/src/jvmTest/kotlin/mu/ClassWithLoggingForLocationTesting.kt
@@ -4,7 +4,7 @@ class ClassWithLoggingForLocationTesting {
     companion object : KLogging()
 
     fun log() {
-        logger.info("test")
+        logger.info { "test" }
     }
 
     fun logLazy() {
@@ -12,18 +12,18 @@ class ClassWithLoggingForLocationTesting {
     }
 
     fun logNull() {
-        logger.info(null)
+        logger.info { null }
     }
 
     fun logEntry(): Pair<Int, Int> {
         logger.entry(1, 2)
-        logger.info("log entry body")
+        logger.info { "log entry body" }
         return logger.exit(2 to 1)
     }
 
     fun logExitOpt(): Pair<Int, Int>? {
         logger.entry(1, 2)
-        logger.info("log entry body")
+        logger.info { "log entry body" }
         return logger.exit(null)
     }
 }

--- a/src/jvmTest/kotlin/mu/KotlinLoggingTest.kt
+++ b/src/jvmTest/kotlin/mu/KotlinLoggingTest.kt
@@ -10,7 +10,7 @@ class ForKotlinLoggingTest {
     val loggerInClass = KotlinLogging.logger { }
 
     companion object {
-        val loggerInCompanion = KotlinLogging.logger { }
+        val loggerInCompanion get() = KotlinLogging.logger { }
     }
 }
 
@@ -20,6 +20,7 @@ class KotlinLoggingTest {
     fun resetState() {
         KotlinLogging.kLoggerFactory = defaultLoggerFactory
     }
+
     @Test
     fun testLoggerName() {
         val logger = KotlinLogging.logger { }

--- a/src/jvmTest/kotlin/mu/KotlinLoggingTest.kt
+++ b/src/jvmTest/kotlin/mu/KotlinLoggingTest.kt
@@ -18,7 +18,7 @@ class KotlinLoggingTest {
 
     @Before
     fun resetState() {
-        KotlinLogging.kLoggerFactory = KotlinLogging.defaultLoggerFactory
+        KotlinLogging.kLoggerFactory = defaultLoggerFactory
     }
     @Test
     fun testLoggerName() {

--- a/src/jvmTest/kotlin/mu/KotlinLoggingTest.kt
+++ b/src/jvmTest/kotlin/mu/KotlinLoggingTest.kt
@@ -1,12 +1,10 @@
 package mu
 
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 import org.slf4j.LoggerFactory
 
-private val logger = KotlinLogging.logger { }
-private val loggerFromSlf4j = KotlinLogging.logger(LoggerFactory.getLogger("mu.slf4jLogger"))
-private val loggerFromSlf4jExtension = LoggerFactory.getLogger("mu.slf4jLoggerExtension").toKLogger()
 
 class ForKotlinLoggingTest {
     val loggerInClass = KotlinLogging.logger { }
@@ -18,12 +16,38 @@ class ForKotlinLoggingTest {
 
 class KotlinLoggingTest {
 
+    @Before
+    fun resetState() {
+        KotlinLogging.kLoggerFactory = KotlinLogging.defaultLoggerFactory
+    }
     @Test
     fun testLoggerName() {
+        val logger = KotlinLogging.logger { }
+        val loggerFromSlf4j = KotlinLogging.logger(LoggerFactory.getLogger("mu.slf4jLogger"))
+        val loggerFromSlf4jExtension = LoggerFactory.getLogger("mu.slf4jLoggerExtension").toKLogger()
+
         assertEquals("mu.KotlinLoggingTest", logger.name)
         assertEquals("mu.ForKotlinLoggingTest", ForKotlinLoggingTest().loggerInClass.name)
         assertEquals("mu.ForKotlinLoggingTest", ForKotlinLoggingTest.loggerInCompanion.name)
         assertEquals("mu.slf4jLogger", loggerFromSlf4j.name)
         assertEquals("mu.slf4jLoggerExtension", loggerFromSlf4jExtension.name)
     }
+
+    @Test
+    fun testNonDefaultLoggerFactory() {
+        KotlinLogging.kLoggerFactory = TestLoggerFactory()
+
+        assertEquals("custom-log-name:passed", KotlinLogging.logger("passed").name)
+        assertEquals("non-default-function", KotlinLogging.logger { }.name)
+        assertEquals("non-default-function", ForKotlinLoggingTest().loggerInClass.name)
+    }
+}
+
+private class TestLoggerFactory : KLoggerFactory {
+    override fun logger(name: String): KLogger = MockedKLogger("custom-log-name:$name")
+
+    override fun logger(func: () -> Unit): KLogger = MockedKLogger("non-default-function")
+
+    override fun logger(loggable: KLoggable): KLogger = MockedKLogger("loggable-based")
+
 }

--- a/src/jvmTest/kotlin/mu/LoggingTest.kt
+++ b/src/jvmTest/kotlin/mu/LoggingTest.kt
@@ -216,7 +216,7 @@ class LoggingTest {
 
     @Test
     fun `check underlyingLogger property`() {
-        Assert.assertEquals("mu.ClassHasLogging", ClassHasLogging().logger.underlyingLogger.name)
+        Assert.assertEquals("mu.ClassHasLogging", ClassHasLogging().logger.name)
     }
 }
 

--- a/src/jvmTest/kotlin/mu/MockedKLogger.kt
+++ b/src/jvmTest/kotlin/mu/MockedKLogger.kt
@@ -1,0 +1,54 @@
+package mu
+
+class MockedKLogger(override val name: String) : KLogger {
+    override fun trace(msg: () -> Any?) = throw NotImplementedError()
+
+    override fun trace(t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun trace(marker: Marker?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun trace(marker: Marker?, t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun debug(msg: () -> Any?) = throw NotImplementedError()
+
+    override fun debug(t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun debug(marker: Marker?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun debug(marker: Marker?, t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun info(msg: () -> Any?) = throw NotImplementedError()
+
+    override fun info(t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun info(marker: Marker?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun info(marker: Marker?, t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun warn(msg: () -> Any?) = throw NotImplementedError()
+
+    override fun warn(t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun warn(marker: Marker?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun warn(marker: Marker?, t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun error(msg: () -> Any?) = throw NotImplementedError()
+
+    override fun error(t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun error(marker: Marker?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun error(marker: Marker?, t: Throwable?, msg: () -> Any?) = throw NotImplementedError()
+
+    override fun entry(vararg argArray: Any?) = throw NotImplementedError()
+
+    override fun exit() = throw NotImplementedError()
+
+    override fun <T> exit(result: T): T = throw NotImplementedError()
+
+    override fun <T : Throwable> throwing(throwable: T): T = throw NotImplementedError()
+
+    override fun <T : Throwable> catching(throwable: T) = throw NotImplementedError()
+
+}

--- a/src/linuxX64Main/kotlin/mu/KLogger.kt
+++ b/src/linuxX64Main/kotlin/mu/KLogger.kt
@@ -3,6 +3,11 @@ package mu
 actual interface KLogger {
 
     /**
+     * Logger Name
+     */
+    actual val name: String
+
+    /**
      * Lazy add a log message if isTraceEnabled is true
      */
     actual fun trace(msg: () -> Any?)

--- a/src/linuxX64Main/kotlin/mu/KLoggerFactory.kt
+++ b/src/linuxX64Main/kotlin/mu/KLoggerFactory.kt
@@ -1,0 +1,9 @@
+package mu
+
+/**
+ * Factory for creating KLoggers
+ */
+actual interface KLoggerFactory {
+    actual fun logger(name: String): KLogger
+    actual fun logger(func: () -> Unit): KLogger
+}

--- a/src/linuxX64Main/kotlin/mu/KotlinLogging.kt
+++ b/src/linuxX64Main/kotlin/mu/KotlinLogging.kt
@@ -1,5 +1,6 @@
 package mu
 
+import mu.internal.KLoggerFactoryDefault
 import mu.internal.KLoggerLinux
 
 
@@ -10,7 +11,9 @@ actual object KotlinLogging {
      * val logger = KotlinLogging.logger {}
      * ```
      */
-    actual fun logger(func: () -> Unit): KLogger = KLoggerLinux(func::class.qualifiedName ?: "")
+    actual fun logger(func: () -> Unit): KLogger = kLoggerFactory.logger(func)
 
-    actual fun logger(name: String): KLogger = KLoggerLinux(name)
+    actual fun logger(name: String): KLogger = kLoggerFactory.logger(name)
+
+    actual var kLoggerFactory: KLoggerFactory = KLoggerFactoryDefault
 }

--- a/src/linuxX64Main/kotlin/mu/internal/KLoggerFactoryDefault.kt
+++ b/src/linuxX64Main/kotlin/mu/internal/KLoggerFactoryDefault.kt
@@ -1,0 +1,21 @@
+package mu.internal
+
+import mu.KLogger
+import mu.KLoggerFactory
+
+/**
+ * factory methods to obtain a [KLogger]
+ */
+@Suppress("NOTHING_TO_INLINE")
+internal actual object KLoggerFactoryDefault : KLoggerFactory {
+    /**
+     * get logger by explicit name
+     */
+    actual override fun logger(name: String): KLogger = KLoggerLinux(name)
+
+    /**
+     * get logger for the method, assuming it was declared at the logger file/class
+     */
+    actual override fun logger(func: () -> Unit): KLogger = logger(func::class.qualifiedName ?: "")
+
+}

--- a/src/linuxX64Main/kotlin/mu/internal/KLoggerLinux.kt
+++ b/src/linuxX64Main/kotlin/mu/internal/KLoggerLinux.kt
@@ -13,7 +13,7 @@ import mu.Marker
 import mu.isLoggingEnabled
 
 internal class KLoggerLinux(
-    private val loggerName: String
+    override val name: String
 ) : KLogger {
 
     override fun trace(msg: () -> Any?) = TRACE.logIfEnabled(msg, appender::trace)
@@ -63,19 +63,19 @@ internal class KLoggerLinux(
 
     private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatter.formatMessage(this, loggerName, msg))
+            logFunction(formatter.formatMessage(this, name, msg))
         }
     }
 
     private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, t: Throwable?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatter.formatMessage(this, loggerName, t, msg))
+            logFunction(formatter.formatMessage(this, name, t, msg))
         }
     }
 
     private fun KotlinLoggingLevel.logIfEnabled(marker: Marker?, msg: () -> Any?, logFunction: (Any?) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatter.formatMessage(this, loggerName, marker, msg))
+            logFunction(formatter.formatMessage(this, name, marker, msg))
         }
     }
 
@@ -86,7 +86,7 @@ internal class KLoggerLinux(
         logFunction: (Any?) -> Unit
     ) {
         if (isLoggingEnabled()) {
-            logFunction(formatter.formatMessage(this, loggerName, marker, t, msg))
+            logFunction(formatter.formatMessage(this, name, marker, t, msg))
         }
     }
 


### PR DESCRIPTION
A proposal for a change that is slightly breaking but allows consumers to create their own kLogger implementations for custom logging environments.  My use-case is for Android apps the SLF4J-Android implementation is deprecated and badly formats exceptions and cuts off most of the stack trace so I used this to have an implementation that in an Android app simply calls the Log.x functions. 

For simplicity it also is a breaking change as it removes the SLF4J logger base interface from KLogger in JVM so I proposed a 2.0 version.  Interested to hear any feedback