### PR TITLE
Support JS-IR backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ stages:
 jobs:
     include:
     - stage: build
-      script: ./gradlew build
+      script: ./gradlew clean build
     - stage: snapshot
-      script: ./gradlew build artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER
+      script: ./gradlew clean build artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER
     - stage: snapshot-1.4
-      script: ./gradlew build artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER
+      script: ./gradlew clean build artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER
     - stage: release
-      script: ./gradlew build bintrayUpload -x test -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER -Dmaven.password=$MAVEN_PASSWORD -Dmaven.user=$MAVEN_USER
+      script: ./gradlew clean build bintrayUpload -x test -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER -Dmaven.password=$MAVEN_PASSWORD -Dmaven.user=$MAVEN_USER
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,12 +57,12 @@ kotlin {
         }
     }
     js {
-        compilations.named("main") {
-            kotlinOptions {
-                metaInfo = true
-                sourceMap = true
-                verbose = true
-                moduleKind = "umd"
+        nodejs()
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                }
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.js.compiler=both


### PR DESCRIPTION
Adds builds for the brower and NodeJS.

Enables JS-IR (with `both` mode).

Should fix #126.