### PR TITLE
don't try to release on non release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ dist: trusty
 stages:
 - name: build
 - name: snapshot
-  if: branch = master AND env(RELEASE_BRANCH) = true
+  if: branch = master AND type = push
 - name: pre-snapshot
-  if: branch = pre-snapshot AND env(RELEASE_BRANCH) = true
+  if: branch = pre-snapshot AND type = push
 - name: release
-  if: branch = release AND env(RELEASE_BRANCH) = true
+  if: branch = release AND type = push
 
 jobs:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,3 @@ jobs:
       script: ./gradlew clean build artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER
     - stage: release
       script: ./gradlew clean build bintrayUpload -x test -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER -Dmaven.password=$MAVEN_PASSWORD -Dmaven.user=$MAVEN_USER
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ dist: trusty
 stages:
 - name: build
 - name: snapshot
-  if: branch = master
-- name: snapshot-1.4
-  if: branch = 1.4.0
+  if: branch = master AND env(RELEASE_BRANCH) = true
+- name: pre-snapshot
+  if: branch = pre-snapshot AND env(RELEASE_BRANCH) = true
 - name: release
-  if: branch = release
+  if: branch = release AND env(RELEASE_BRANCH) = true
 
 jobs:
     include:
@@ -20,7 +20,7 @@ jobs:
       script: ./gradlew clean build
     - stage: snapshot
       script: ./gradlew clean build artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER
-    - stage: snapshot-1.4
+    - stage: pre-snapshot
       script: ./gradlew clean build artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER
     - stage: release
       script: ./gradlew clean build bintrayUpload -x test -Dbintray.user=$BINTRAY_USER -Dbintray.key=$BINTRAY_API_KEY -Dbuild.number=$TRAVIS_BUILD_NUMBER -Dmaven.password=$MAVEN_PASSWORD -Dmaven.user=$MAVEN_USER


### PR DESCRIPTION
Since the addition of release builds,
travis is trying to deploy PR that are coming from
a master branch because of the 'branch = master' condition.
To overcome this added a special env variable RELEASE_BRANCH that is set only on the release branches and checking it for release.