### PR TITLE
Add `import mu.KotlinLogging;` statement to getting started in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ logger.error(exception) { "a $fancy message about the $exception" }
 ## Getting started
  
 ```Kotlin
+import mu.KotlinLogging;
 private val logger = KotlinLogging.logger {} 
 class FooWithLogging {
     val message = "world"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ logger.error(exception) { "a $fancy message about the $exception" }
 ## Getting started
  
 ```Kotlin
-import mu.KotlinLogging;
+import mu.KotlinLogging
 private val logger = KotlinLogging.logger {} 
 class FooWithLogging {
     val message = "world"


### PR DESCRIPTION
Setup with this library was super easy except that it wasn't obvious from the main README what the import line for KotlinLogging should be. Adding it in the getting started example would have been handy for me, maybe it'll help others?