### PR TITLE
Fix #160 - throw error instead of show in log

### DIFF
--- a/src/commonMain/kotlin/mu/internal/MessageInvoker.kt
+++ b/src/commonMain/kotlin/mu/internal/MessageInvoker.kt
@@ -5,6 +5,10 @@ internal inline fun (() -> Any?).toStringSafe(): String {
     return try {
         invoke().toString()
     } catch (e: Exception) {
-        "Log message invocation failed: $e"
+        ErrorMessageProducer.getErrorLog(e)
     }
+}
+
+public expect object ErrorMessageProducer {
+    public fun getErrorLog(e: Exception): String
 }

--- a/src/jsMain/kotlin/mu/internal/ErrorMessageProducer.kt
+++ b/src/jsMain/kotlin/mu/internal/ErrorMessageProducer.kt
@@ -1,0 +1,5 @@
+package mu.internal
+
+public actual object ErrorMessageProducer {
+    public actual fun getErrorLog(e: Exception): String = "Log message invocation failed: $e"
+}

--- a/src/jvmMain/kotlin/mu/internal/ErrorMessageProducer.kt
+++ b/src/jvmMain/kotlin/mu/internal/ErrorMessageProducer.kt
@@ -1,0 +1,12 @@
+package mu.internal
+
+public actual object ErrorMessageProducer {
+    public actual fun getErrorLog(e: Exception): String  {
+      if (System.getProperties().containsKey("kotlin-logging.throwOnMessageError")) {
+          throw e
+      } else {
+          return "Log message invocation failed: $e"
+      }
+    }
+
+}

--- a/src/jvmTest/kotlin/mu/internal/MessageInvokerJavaTest.kt
+++ b/src/jvmTest/kotlin/mu/internal/MessageInvokerJavaTest.kt
@@ -1,0 +1,27 @@
+package mu.internal
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class MessageInvokerJavaTest {
+
+    @Test
+    fun toStringSafeChecks() {
+        assertEquals("hi", { "hi" }.toStringSafe())
+    }
+
+    @Test
+    fun toStringSafeChecksThrowException() {
+        assertEquals("Log message invocation failed: java.lang.Exception: hi", { throw Exception("hi") }.toStringSafe())
+    }
+
+    @Test(expected = Exception::class)
+    fun toStringSafeChecksThrowExceptionWithSystemProperty() {
+        System.setProperty("kotlin-logging.throwOnMessageError", "")
+        try {
+            { throw Exception("hi") }.toStringSafe()
+        } finally {
+          System.clearProperty("kotlin-logging.throwOnMessageError")
+        }
+    }
+}

--- a/src/nativeMain/kotlin/mu/internal/ErrorMessageProducer.kt
+++ b/src/nativeMain/kotlin/mu/internal/ErrorMessageProducer.kt
@@ -1,0 +1,5 @@
+package mu.internal
+
+public actual object ErrorMessageProducer {
+    public actual fun getErrorLog(e: Exception): String = "Log message invocation failed: $e"
+}


### PR DESCRIPTION
in case system property is defined: kotlin-logging.throwOnMessageError