### PR TITLE
Support nullables in withLoggingContext

### DIFF
--- a/src/jvmMain/kotlin/mu/KotlinLoggingMDC.kt
+++ b/src/jvmMain/kotlin/mu/KotlinLoggingMDC.kt
@@ -10,8 +10,12 @@ import org.slf4j.MDC
  * }
  * ```
  */
-public inline fun <T> withLoggingContext(pair: Pair<String, String>, body: () -> T): T =
-    MDC.putCloseable(pair.first, pair.second).use { body() }
+public inline fun <T> withLoggingContext(pair: Pair<String, String?>, body: () -> T): T =
+    if (pair.second != null) {
+        MDC.putCloseable(pair.first, pair.second).use { body() }
+    } else {
+        body()
+    }
 
 /**
  * Use a vary number of pairs in MDC context. Example:
@@ -21,12 +25,12 @@ public inline fun <T> withLoggingContext(pair: Pair<String, String>, body: () ->
  * }
  * ```
  */
-public inline fun <T> withLoggingContext(vararg pair: Pair<String, String>, body: () -> T): T {
+public inline fun <T> withLoggingContext(vararg pair: Pair<String, String?>, body: () -> T): T {
     try {
-        pair.forEach { MDC.put(it.first, it.second) }
+        pair.filter { it.second != null }.forEach { MDC.put(it.first, it.second) }
         return body()
     } finally {
-        pair.forEach { MDC.remove(it.first) }
+        pair.filter { it.second != null }.forEach { MDC.remove(it.first) }
     }
 }
 

--- a/src/jvmTest/kotlin/mu/KotlinLoggingMDCTest.kt
+++ b/src/jvmTest/kotlin/mu/KotlinLoggingMDCTest.kt
@@ -22,6 +22,15 @@ class KotlinLoggingMDCTest {
     }
 
     @Test
+    fun `simple nullable pair withLoggingContext`() {
+        assertNull(MDC.get("a"))
+        withLoggingContext("a" to null) {
+            assertNull(MDC.get("a"))
+        }
+        assertNull(MDC.get("a"))
+    }
+
+    @Test
     fun `multiple pair withLoggingContext`() {
         assertNull(MDC.get("a"))
         assertNull(MDC.get("c"))
@@ -31,6 +40,21 @@ class KotlinLoggingMDCTest {
         }
         assertNull(MDC.get("a"))
         assertNull(MDC.get("c"))
+    }
+
+    @Test
+    fun `multiple nullable pair withLoggingContext`() {
+        assertNull(MDC.get("a"))
+        assertNull(MDC.get("c"))
+        MDC.put("e", "f")
+        withLoggingContext("a" to "b", "c" to null, "e" to null) {
+            assertEquals("b", MDC.get("a"))
+            assertNull(MDC.get("c"))
+            assertEquals("f", MDC.get("e"))
+        }
+        assertNull(MDC.get("a"))
+        assertNull(MDC.get("c"))
+        assertEquals("f", MDC.get("e"))
     }
 
     @Test


### PR DESCRIPTION
`withLoggingContext` now accepts nullable values that won't be written
to the `MDC` (and thus also don't overwrite existing values).
This might be useful if some values are not guaranteed to exist, but you
want them in the `MDC` if possible.

Issue: #172