### PR TITLE
Allow Any in withLoggingContext

### DIFF
--- a/src/jvmMain/kotlin/mu/KotlinLoggingMDC.kt
+++ b/src/jvmMain/kotlin/mu/KotlinLoggingMDC.kt
@@ -10,9 +10,9 @@ import org.slf4j.MDC
  * }
  * ```
  */
-public inline fun <T> withLoggingContext(pair: Pair<String, String?>, body: () -> T): T =
+public inline fun <T> withLoggingContext(pair: Pair<String, Any?>, body: () -> T): T =
     if (pair.second != null) {
-        MDC.putCloseable(pair.first, pair.second).use { body() }
+        MDC.putCloseable(pair.first, pair.second.toString()).use { body() }
     } else {
         body()
     }
@@ -25,9 +25,9 @@ public inline fun <T> withLoggingContext(pair: Pair<String, String?>, body: () -
  * }
  * ```
  */
-public inline fun <T> withLoggingContext(vararg pair: Pair<String, String?>, body: () -> T): T {
+public inline fun <T> withLoggingContext(vararg pair: Pair<String, Any?>, body: () -> T): T {
     try {
-        pair.filter { it.second != null }.forEach { MDC.put(it.first, it.second) }
+        pair.filter { it.second != null }.forEach { MDC.put(it.first, it.second.toString()) }
         return body()
     } finally {
         pair.filter { it.second != null }.forEach { MDC.remove(it.first) }

--- a/src/jvmTest/kotlin/mu/KotlinLoggingMDCTest.kt
+++ b/src/jvmTest/kotlin/mu/KotlinLoggingMDCTest.kt
@@ -31,6 +31,15 @@ class KotlinLoggingMDCTest {
     }
 
     @Test
+    fun `simple toString pair withLoggingContext`() {
+        assertNull(MDC.get("a"))
+        withLoggingContext("a" to 15) {
+            assertEquals("15", MDC.get("a"))
+        }
+        assertNull(MDC.get("a"))
+    }
+
+    @Test
     fun `multiple pair withLoggingContext`() {
         assertNull(MDC.get("a"))
         assertNull(MDC.get("c"))
@@ -58,6 +67,18 @@ class KotlinLoggingMDCTest {
     }
 
     @Test
+    fun `multiple toString pair withLoggingContext`() {
+        assertNull(MDC.get("a"))
+        assertNull(MDC.get("c"))
+        withLoggingContext("a" to true, "c" to ToStringObject()) {
+            assertEquals("true", MDC.get("a"))
+            assertEquals("string", MDC.get("c"))
+        }
+        assertNull(MDC.get("a"))
+        assertNull(MDC.get("c"))
+    }
+
+    @Test
     fun `map withLoggingContext`() {
         assertNull(MDC.get("a"))
         assertNull(MDC.get("c"))
@@ -67,5 +88,11 @@ class KotlinLoggingMDCTest {
         }
         assertNull(MDC.get("a"))
         assertNull(MDC.get("c"))
+    }
+}
+
+private class ToStringObject {
+    override fun toString(): String {
+        return "string"
     }
 }


### PR DESCRIPTION
I hope it's okay that I opened a PR without an issue first 🙂

To make calls even more comfortable, `withLogginContext` now accepts `Any?` as a value and will convert it to a `String` itself.