### PR TITLE
split travis targets to linux and osx jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,32 @@ language: java
 jdk:
   - openjdk11
 
-dist: trusty
-
-os:
-  - linux
-  - osx
-
-osx_image: xcode11.6
-
 addons:
   chrome: stable
 
 stages:
-  - name: build
-  - name: release
+  - name: build-linux
+  - name: build-osx
+  - name: release-linux
+    if: branch IN (release) AND type = push
+  - name: release-osx
     if: branch IN (release) AND type = push
 
 jobs:
   include:
-    - stage: build
+    - stage: build-linux
       script: ./gradlew clean build
-    - stage: release
+      os: linux
+      dist: trusty
+    - stage: build-osx
+      script: ./gradlew clean build
+      os: osx
+      osx_image: xcode11.6
+    - stage: release-linux
       script: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -no-daemon --no-parallel
+      os: linux
+      dist: trusty
+    - stage: release-osx
+      script: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -no-daemon --no-parallel
+      os: osx
+      osx_image: xcode11.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,13 @@ jobs:
       os: osx
       osx_image: xcode11.6
     - stage: release-linux
-      script: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -no-daemon --no-parallel
+      script: ./gradlew publishToSonatype -no-daemon --no-parallel
       os: linux
       dist: trusty
     - stage: release-osx
-      script: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -no-daemon --no-parallel
+      script: ./gradlew publishToSonatype -no-daemon --no-parallel
       os: osx
       osx_image: xcode11.6
+
+# Requires to manually release a new version on https://s01.oss.sonatype.org/#stagingRepositories
+# add back closeAndReleaseSonatypeStagingRepository to fully automate the release but I suspect it will have a conflict with multiple jobs


### PR DESCRIPTION
osx is now built, but not released. trying to split travis jobs for build+release to also release it.

Part of issue #166 