### PR TITLE
Upgraded log4j from 2.15.0 to 2.16.0 (CVE-2021-45046)

### DIFF
--- a/versions.gradle.kts
+++ b/versions.gradle.kts
@@ -1,4 +1,4 @@
 extra["slf4j_version"] = "1.7.32"
-extra["log4j_version"] = "2.15.0"
+extra["log4j_version"] = "2.16.0"
 extra["mockito_version"] = "1.10.19"
 extra["junit_version"] = "5.8.2"


### PR DESCRIPTION
For resolve problem of Security Vulnerabilities (CVE-2021-45046)

https://logging.apache.org/log4j/2.x/security.html