### PR TITLE
Add support for os_log on Apple platforms

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,9 +51,24 @@ kotlin {
         nodejs()
     }
 
-    linuxX64("linuxX64")
-    macosX64("macosX64")
-    mingwX64("mingwX64")
+    val linuxTargets = listOf(
+        linuxArm64(),
+        linuxX64(),
+        mingwX64()
+    )
+    val darwinTargets = listOf(
+        macosArm64(),
+        macosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+        iosX64(),
+        watchosArm64(),
+        watchosSimulatorArm64(),
+        watchosX64(),
+        tvosArm64(),
+        tvosSimulatorArm64(),
+        tvosX64()
+    )
 
     sourceSets {
         val commonMain by getting {}
@@ -88,14 +103,21 @@ kotlin {
         val nativeMain by creating {
             dependsOn(commonMain)
         }
-        val linuxX64Main by getting {
+        val linuxMain by creating {
             dependsOn(nativeMain)
         }
-        val mingwX64Main by getting {
+        val darwinMain by creating {
             dependsOn(nativeMain)
         }
-        val macosX64Main by getting {
-            dependsOn(nativeMain)
+        linuxTargets.forEach {
+            getByName("${it.targetName}Main") {
+                dependsOn(linuxMain)
+            }
+        }
+        darwinTargets.forEach {
+            getByName("${it.targetName}Main") {
+                dependsOn(darwinMain)
+            }
         }
     }
 }

--- a/src/darwinMain/kotlin/mu/KotlinLoggingConfiguration.kt
+++ b/src/darwinMain/kotlin/mu/KotlinLoggingConfiguration.kt
@@ -1,0 +1,3 @@
+package mu
+
+public actual val DefaultAppender: Appender = OSLogAppender()

--- a/src/darwinMain/kotlin/mu/OSLogAppender.kt
+++ b/src/darwinMain/kotlin/mu/OSLogAppender.kt
@@ -1,0 +1,49 @@
+package mu
+
+import kotlinx.cinterop.ptr
+import platform.darwin.OS_LOG_DEFAULT
+import platform.darwin.OS_LOG_TYPE_DEBUG
+import platform.darwin.OS_LOG_TYPE_DEFAULT
+import platform.darwin.OS_LOG_TYPE_ERROR
+import platform.darwin.OS_LOG_TYPE_INFO
+import platform.darwin.__dso_handle
+import platform.darwin._os_log_internal
+import platform.darwin.os_log_t
+import platform.darwin.os_log_type_enabled
+import platform.darwin.os_log_type_t
+import kotlin.native.concurrent.AtomicReference
+
+public open class OSLogAppender: Appender {
+    override val includePrefix: Boolean = true
+
+    protected open fun logger(loggerName: String): os_log_t {
+        return OS_LOG_DEFAULT
+    }
+
+    private fun log(level: os_log_type_t, loggerName: String, message: String) {
+        val logger = logger(loggerName)
+        if (os_log_type_enabled(logger, level)) {
+            _os_log_internal(__dso_handle.ptr, logger, level, message)
+        }
+    }
+
+    override fun trace(loggerName: String, message: String) {
+        log(OS_LOG_TYPE_DEBUG, loggerName, message)
+    }
+
+    override fun debug(loggerName: String, message: String) {
+        log(OS_LOG_TYPE_DEBUG, loggerName, message)
+    }
+
+    override fun info(loggerName: String, message: String) {
+        log(OS_LOG_TYPE_INFO, loggerName, message)
+    }
+
+    override fun warn(loggerName: String, message: String) {
+        log(OS_LOG_TYPE_DEFAULT, loggerName, message)
+    }
+
+    override fun error(loggerName: String, message: String) {
+        log(OS_LOG_TYPE_ERROR, loggerName, message)
+    }
+}

--- a/src/darwinMain/kotlin/mu/OSLogSubsystemAppender.kt
+++ b/src/darwinMain/kotlin/mu/OSLogSubsystemAppender.kt
@@ -1,0 +1,28 @@
+package mu
+
+import platform.darwin.os_log_create
+import platform.darwin.os_log_t
+import kotlin.native.concurrent.AtomicReference
+
+public class OSLogSubsystemAppender(public val subsystem: String) : OSLogAppender() {
+    override val includePrefix: Boolean = false
+
+    private val logs: AtomicReference<Map<String, os_log_t>> = AtomicReference(mapOf())
+
+    override fun logger(loggerName: String): os_log_t {
+        var logger: os_log_t
+        do {
+            val existing = logs.value
+            logger = existing[loggerName]
+            if (logger != null) {
+                return logger
+            }
+
+            val updated = existing.toMutableMap()
+            logger = os_log_create(subsystem, loggerName)
+            updated[loggerName] = logger
+        } while (!logs.compareAndSet(existing, updated))
+
+        return logger
+    }
+}

--- a/src/linuxMain/kotlin/mu/KotlinLoggingConfiguration.kt
+++ b/src/linuxMain/kotlin/mu/KotlinLoggingConfiguration.kt
@@ -1,0 +1,3 @@
+package mu
+
+public actual val DefaultAppender: Appender = ConsoleOutputAppender

--- a/src/nativeMain/kotlin/mu/Appender.kt
+++ b/src/nativeMain/kotlin/mu/Appender.kt
@@ -1,9 +1,9 @@
 package mu
 
 public interface Appender {
-    public fun trace(message: Any?)
-    public fun debug(message: Any?)
-    public fun info(message: Any?)
-    public fun warn(message: Any?)
-    public fun error(message: Any?)
+    public fun trace(loggerName: String, message: String)
+    public fun debug(loggerName: String, message: String)
+    public fun info(loggerName: String, message: String)
+    public fun warn(loggerName: String, message: String)
+    public fun error(loggerName: String, message: String)
 }

--- a/src/nativeMain/kotlin/mu/Appender.kt
+++ b/src/nativeMain/kotlin/mu/Appender.kt
@@ -1,6 +1,8 @@
 package mu
 
 public interface Appender {
+    public val includePrefix: Boolean
+
     public fun trace(loggerName: String, message: String)
     public fun debug(loggerName: String, message: String)
     public fun info(loggerName: String, message: String)

--- a/src/nativeMain/kotlin/mu/ConsoleOutputAppender.kt
+++ b/src/nativeMain/kotlin/mu/ConsoleOutputAppender.kt
@@ -4,12 +4,12 @@ import platform.posix.fprintf
 import platform.posix.stderr
 
 public object ConsoleOutputAppender : Appender {
-    public override fun trace(message: Any?): Unit = println(message)
-    public override fun debug(message: Any?): Unit = println(message)
-    public override fun info(message: Any?): Unit = println(message)
-    public override fun warn(message: Any?): Unit = println(message)
+    public override fun trace(loggerName: String, message: String): Unit = println(message)
+    public override fun debug(loggerName: String, message: String): Unit = println(message)
+    public override fun info(loggerName: String, message: String): Unit = println(message)
+    public override fun warn(loggerName: String, message: String): Unit = println(message)
 
-    override fun error(message: Any?) {
+    override fun error(loggerName: String, message: String) {
         fprintf(stderr, "$message\n")
     }
 }

--- a/src/nativeMain/kotlin/mu/ConsoleOutputAppender.kt
+++ b/src/nativeMain/kotlin/mu/ConsoleOutputAppender.kt
@@ -4,6 +4,7 @@ import platform.posix.fprintf
 import platform.posix.stderr
 
 public object ConsoleOutputAppender : Appender {
+    override val includePrefix: Boolean = true
     public override fun trace(loggerName: String, message: String): Unit = println(message)
     public override fun debug(loggerName: String, message: String): Unit = println(message)
     public override fun info(loggerName: String, message: String): Unit = println(message)

--- a/src/nativeMain/kotlin/mu/DefaultMessageFormatter.kt
+++ b/src/nativeMain/kotlin/mu/DefaultMessageFormatter.kt
@@ -3,23 +3,32 @@ package mu
 import mu.internal.toStringSafe
 
 public object DefaultMessageFormatter : Formatter {
-    public override fun formatMessage(level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?): String =
-        "${level.name}: [$loggerName] ${msg.toStringSafe()}"
+    public override fun formatMessage(includePrefix: Boolean, level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?): String =
+        "${prefix(includePrefix, level, loggerName)}${msg.toStringSafe()}"
 
-    public override fun formatMessage(level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?): String =
-        "${level.name}: [$loggerName] ${msg.toStringSafe()}${t.throwableToString()}"
+    public override fun formatMessage(includePrefix: Boolean, level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?): String =
+        "${prefix(includePrefix, level, loggerName)}${msg.toStringSafe()}${t.throwableToString()}"
 
-    public override fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?): String =
-        "${level.name}: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}"
+    public override fun formatMessage(includePrefix: Boolean, level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?): String =
+        "${prefix(includePrefix, level, loggerName)}${marker?.getName()} ${msg.toStringSafe()}"
 
     public override fun formatMessage(
+        includePrefix: Boolean,
         level: KotlinLoggingLevel,
         loggerName: String,
         marker: Marker?,
         t: Throwable?,
         msg: () -> Any?
     ): String =
-        "${level.name}: [$loggerName] ${marker?.getName()} ${msg.toStringSafe()}${t.throwableToString()}"
+        "${prefix(includePrefix, level, loggerName)}${marker?.getName()} ${msg.toStringSafe()}${t.throwableToString()}"
+
+    private fun prefix(includePrefix: Boolean, level: KotlinLoggingLevel, loggerName: String): String {
+        return if (includePrefix) {
+            "${level.name}: [$loggerName] "
+        } else {
+            ""
+        }
+    }
 
     private fun Throwable?.throwableToString(): String {
         if (this == null) {

--- a/src/nativeMain/kotlin/mu/Formatter.kt
+++ b/src/nativeMain/kotlin/mu/Formatter.kt
@@ -1,14 +1,14 @@
 package mu
 
 public interface Formatter {
-    public fun formatMessage(level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?): Any?
-    public fun formatMessage(level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?): Any?
-    public fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?): Any?
+    public fun formatMessage(level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?): String
+    public fun formatMessage(level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?): String
+    public fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?): String
     public fun formatMessage(
         level: KotlinLoggingLevel,
         loggerName: String,
         marker: Marker?,
         t: Throwable?,
         msg: () -> Any?
-    ): Any?
+    ): String
 }

--- a/src/nativeMain/kotlin/mu/Formatter.kt
+++ b/src/nativeMain/kotlin/mu/Formatter.kt
@@ -1,10 +1,11 @@
 package mu
 
 public interface Formatter {
-    public fun formatMessage(level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?): String
-    public fun formatMessage(level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?): String
-    public fun formatMessage(level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?): String
+    public fun formatMessage(includePrefix: Boolean, level: KotlinLoggingLevel, loggerName: String, msg: () -> Any?): String
+    public fun formatMessage(includePrefix: Boolean, level: KotlinLoggingLevel, loggerName: String, t: Throwable?, msg: () -> Any?): String
+    public fun formatMessage(includePrefix: Boolean, level: KotlinLoggingLevel, loggerName: String, marker: Marker?, msg: () -> Any?): String
     public fun formatMessage(
+        includePrefix: Boolean,
         level: KotlinLoggingLevel,
         loggerName: String,
         marker: Marker?,

--- a/src/nativeMain/kotlin/mu/KMarkerFactory.kt
+++ b/src/nativeMain/kotlin/mu/KMarkerFactory.kt
@@ -1,8 +1,8 @@
 package mu
 
-import mu.internal.MarkerLinux
+import mu.internal.MarkerNative
 
 public actual object KMarkerFactory {
 
-    public actual fun getMarker(name: String): Marker = MarkerLinux(name)
+    public actual fun getMarker(name: String): Marker = MarkerNative(name)
 }

--- a/src/nativeMain/kotlin/mu/KotlinLoggingConfiguration.kt
+++ b/src/nativeMain/kotlin/mu/KotlinLoggingConfiguration.kt
@@ -2,6 +2,8 @@ package mu
 
 import kotlin.native.concurrent.AtomicReference
 
+public expect val DefaultAppender: Appender
+
 @Suppress("ObjectPropertyName")
 public object KotlinLoggingConfiguration {
     private val _logLevel = AtomicReference(KotlinLoggingLevel.INFO)
@@ -10,7 +12,7 @@ public object KotlinLoggingConfiguration {
         set(value) {
             _logLevel.value = value
         }
-    private val _appender = AtomicReference<Appender>(ConsoleOutputAppender)
+    private val _appender = AtomicReference<Appender>(DefaultAppender)
     public var appender: Appender
         get() = _appender.value
         set(value) {

--- a/src/nativeMain/kotlin/mu/internal/KLoggerLinux.kt
+++ b/src/nativeMain/kotlin/mu/internal/KLoggerLinux.kt
@@ -59,19 +59,19 @@ internal class KLoggerLinux(
 
     private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, logFunction: (String, String) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(loggerName, formatter.formatMessage(this, loggerName, msg))
+            logFunction(loggerName, formatter.formatMessage(appender.includePrefix, this, loggerName, msg))
         }
     }
 
     private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, t: Throwable?, logFunction: (String, String) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(loggerName, formatter.formatMessage(this, loggerName, t, msg))
+            logFunction(loggerName, formatter.formatMessage(appender.includePrefix, this, loggerName, t, msg))
         }
     }
 
     private fun KotlinLoggingLevel.logIfEnabled(marker: Marker?, msg: () -> Any?, logFunction: (String, String) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(loggerName, formatter.formatMessage(this, loggerName, marker, msg))
+            logFunction(loggerName, formatter.formatMessage(appender.includePrefix, this, loggerName, marker, msg))
         }
     }
 
@@ -82,7 +82,7 @@ internal class KLoggerLinux(
         logFunction: (String, String) -> Unit
     ) {
         if (isLoggingEnabled()) {
-            logFunction(loggerName, formatter.formatMessage(this, loggerName, marker, t, msg))
+            logFunction(loggerName, formatter.formatMessage(appender.includePrefix, this, loggerName, marker, t, msg))
         }
     }
 

--- a/src/nativeMain/kotlin/mu/internal/KLoggerLinux.kt
+++ b/src/nativeMain/kotlin/mu/internal/KLoggerLinux.kt
@@ -57,21 +57,21 @@ internal class KLoggerLinux(
     override fun error(marker: Marker?, t: Throwable?, msg: () -> Any?) =
         ERROR.logIfEnabled(marker, msg, t, appender::error)
 
-    private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, logFunction: (Any?) -> Unit) {
+    private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, logFunction: (String, String) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatter.formatMessage(this, loggerName, msg))
+            logFunction(loggerName, formatter.formatMessage(this, loggerName, msg))
         }
     }
 
-    private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, t: Throwable?, logFunction: (Any?) -> Unit) {
+    private fun KotlinLoggingLevel.logIfEnabled(msg: () -> Any?, t: Throwable?, logFunction: (String, String) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatter.formatMessage(this, loggerName, t, msg))
+            logFunction(loggerName, formatter.formatMessage(this, loggerName, t, msg))
         }
     }
 
-    private fun KotlinLoggingLevel.logIfEnabled(marker: Marker?, msg: () -> Any?, logFunction: (Any?) -> Unit) {
+    private fun KotlinLoggingLevel.logIfEnabled(marker: Marker?, msg: () -> Any?, logFunction: (String, String) -> Unit) {
         if (isLoggingEnabled()) {
-            logFunction(formatter.formatMessage(this, loggerName, marker, msg))
+            logFunction(loggerName, formatter.formatMessage(this, loggerName, marker, msg))
         }
     }
 
@@ -79,10 +79,10 @@ internal class KLoggerLinux(
         marker: Marker?,
         msg: () -> Any?,
         t: Throwable?,
-        logFunction: (Any?) -> Unit
+        logFunction: (String, String) -> Unit
     ) {
         if (isLoggingEnabled()) {
-            logFunction(formatter.formatMessage(this, loggerName, marker, t, msg))
+            logFunction(loggerName, formatter.formatMessage(this, loggerName, marker, t, msg))
         }
     }
 

--- a/src/nativeMain/kotlin/mu/internal/MarkerNative.kt
+++ b/src/nativeMain/kotlin/mu/internal/MarkerNative.kt
@@ -2,7 +2,7 @@ package mu.internal
 
 import mu.Marker
 
-internal class MarkerLinux(private val name: String) : Marker {
+internal class MarkerNative(private val name: String) : Marker {
 
     override fun getName(): String = this.name
 }


### PR DESCRIPTION
Apple platforms (macOS, iOS, watchOS, tvOS) have a [unified logging system](https://developer.apple.com/documentation/os/logging?language=objc) called `os_log`. I implemented support for `os_log` and made it the default on Apple platforms. This is similar to how `slf4j-android` implements `slf4j-api` to write to the Android system log.

I kept the console output appender still available on Apple platforms because it might still be desirable to use it in, for example, a command line tool.

`os_log` has two key concepts – a subsystem and a category. A subsystem is intended to be constant for an entire project (i.e. the reverse DNS notation for the project) and the category is supposed to change based on the component. Neither are usually part of the log message string itself, but rather used for filtering the log messages. If you have a subsystem and a category, you can create a log object with [`os_log_create(2)`](https://developer.apple.com/documentation/os/1643744-os_log_create), but if you don't have either you can just use [`OS_LOG_DEFAULT`](https://developer.apple.com/documentation/os/os_log_default)

My implementation makes `OS_LOG_DEFAULT` the default for Apple platforms, but you can specify a subsystem with:

```
KotlinLoggingConfiguration.appender = OSLogSubsystemAppender("com.example.app")
```

If you are using the default log, the `loggerName` is logged as a part of the message, but if you are using a specific subsystem, the `loggerName` will instead be used as the category. Similar to the subsystem and the category `os_log` also makes the level a parameter of the message itself (and something you can filter on), instead of as a part of the message text.

I hide the log level and `loggerName` if you are using a `OSLogSubsystemAppender`, but this part of the diff is a bit rough, and I'd love your thoughts on which direction it should go. For the time being, it works for my needs :)

`os_log` also has the ability to disable log levels for performance, and my implementation supports that as well.

Thank you for writing this library, it is working great for me! Feel free to suggest changes, or to just make them yourself – the branch is yours 😊

One small note is that Kotlin multiplatform handles the artifact multiplexing automatically – I am able to just specify the single `io.github.microutils:kotlin-logging` dependency in my `commonMain` and It Just Works™