### PR TITLE
build(deps): bump log4j from 2.18.0 to 2.19.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ kotlin {
                 implementation("org.mockito:mockito-all:${extra["mockito_version"]}")
                 implementation("org.apache.logging.log4j:log4j-api:${extra["log4j_version"]}")
                 implementation("org.apache.logging.log4j:log4j-core:${extra["log4j_version"]}")
-                implementation("org.apache.logging.log4j:log4j-slf4j-impl:${extra["log4j_version"]}")
+                implementation("org.apache.logging.log4j:log4j-slf4j2-impl:${extra["log4j_version"]}")
             }
         }
         val jsMain by getting {}

--- a/versions.gradle.kts
+++ b/versions.gradle.kts
@@ -1,4 +1,4 @@
-extra["slf4j_version"] = "1.7.32"
-extra["log4j_version"] = "2.18.0"
+extra["slf4j_version"] = "2.0.1"
+extra["log4j_version"] = "2.19.0"
 extra["mockito_version"] = "1.10.19"
 extra["junit_version"] = "5.8.2"


### PR DESCRIPTION
Bump log4j from 2.18.0 to 2.19.0

- Bumps log4j from 2.18.0 to 2.19.0
- Bumps slf4j from 1.7.32 to 2.0.1
- Migrates to `log4j-slf4j2`. See https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/index.html



Release notes: 

log4j : https://logging.apache.org/log4j/2.x/changes-report.html#a2.19.0
slf4j  : https://www.slf4j.org/faq.html#changesInVersion200