### PR TITLE
build(deps): bump log4j from 2.17.1 to 2.18.0

### DIFF
--- a/versions.gradle.kts
+++ b/versions.gradle.kts
@@ -1,4 +1,4 @@
 extra["slf4j_version"] = "1.7.32"
-extra["log4j_version"] = "2.17.1"
+extra["log4j_version"] = "2.18.0"
 extra["mockito_version"] = "1.10.19"
 extra["junit_version"] = "5.8.2"


### PR DESCRIPTION
Release notes: https://logging.apache.org/log4j/2.x/changes-report.html#a2.18.0