### PR TITLE
build(test-dep): Migrate to mockito-core

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ kotlin {
                 implementation(kotlin("test"))
                 implementation("org.junit.jupiter:junit-jupiter-engine:${extra["junit_version"]}")
                 implementation("org.junit.jupiter:junit-jupiter-params:${extra["junit_version"]}")
-                implementation("org.mockito:mockito-all:${extra["mockito_version"]}")
+                implementation("org.mockito:mockito-core:${extra["mockito_version"]}")
                 implementation("org.apache.logging.log4j:log4j-api:${extra["log4j_version"]}")
                 implementation("org.apache.logging.log4j:log4j-core:${extra["log4j_version"]}")
                 implementation("org.apache.logging.log4j:log4j-slf4j2-impl:${extra["log4j_version"]}")

--- a/versions.gradle.kts
+++ b/versions.gradle.kts
@@ -1,4 +1,4 @@
 extra["slf4j_version"] = "2.0.3"
 extra["log4j_version"] = "2.19.0"
-extra["mockito_version"] = "1.10.19"
+extra["mockito_version"] = "4.8.0"
 extra["junit_version"] = "5.9.1"


### PR DESCRIPTION
The release [mockito-all](https://search.maven.org/artifact/org.mockito/mockito-all) is [1.10.19](https://search.maven.org/artifact/org.mockito/mockito-all/1.10.19/jar) and that was released in 2014. Newer versions of Mockito don't release mockito-all anymore.