### PR TITLE
build(deps): bump kotlin multiplatform from 1.7.20 to 1.7.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.jvm.tasks.Jar
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 
 plugins {
-    kotlin("multiplatform") version "1.7.20"
+    kotlin("multiplatform") version "1.7.21"
     id("org.jetbrains.dokka") version "1.7.10"
     `maven-publish`
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"


### PR DESCRIPTION
See https://github.com/JetBrains/kotlin/releases/tag/v1.7.21