### PR TITLE
upgrade dokka to v2

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -36,7 +36,7 @@ jobs:
           java-version: 17
 
       - name: Generate Dokka HTML docs
-        run: ./gradlew :dokkaHtml
+        run: ./gradlew :dokkaGenerate
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -285,11 +285,27 @@ tasks {
 
 // Docs
 
-tasks {
-    register<Jar>("dokkaJar") {
-        from(dokkaHtml)
-        dependsOn(dokkaHtml)
-        archiveClassifier.set("javadoc")
+tasks.register("javadocJar", Jar::class) {
+    archiveClassifier.set("javadoc")
+}
+
+dependencies {
+    dokka(project(":"))
+}
+
+dokka {
+    moduleName.set("kotlin-logging")
+    dokkaSourceSets {
+        configureEach {
+            sourceLink {
+                localDirectory.set(project.projectDir.resolve("src"))
+                remoteUrl.set(uri("https://github.com/oshai/kotlin-logging/tree/master/src"))
+                remoteLineSuffix.set("#L")
+            }
+        }
+    }
+    dokkaPublications.html {
+        outputDirectory.set(project.layout.buildDirectory.dir("dokka"))
     }
 }
 
@@ -357,7 +373,7 @@ publishing {
                 url.set("https://github.com/oshai/kotlin-logging/tree/master")
             }
         }
-        artifact(tasks["dokkaJar"])
+        
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ org.gradle.jvmargs=-Xmx2048m
 # see https://kotlinlang.org/docs/whatsnew18.html#sourcedirectories
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.applyDefaultHierarchyTemplate=false
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
following instructions in:
https://kotlinlang.org/docs/dokka-migration.html

reverted to v1 because of two issues:
- no platform matrix in html
- links were broken (missing kotlin-logging)