### PR TITLE
Change LogbackLogEvent to implement ILoggingEvent

### DIFF
--- a/src/jvmMain/kotlin/io/github/oshai/kotlinlogging/logback/internal/LogbackLogEvent.kt
+++ b/src/jvmMain/kotlin/io/github/oshai/kotlinlogging/logback/internal/LogbackLogEvent.kt
@@ -71,7 +71,8 @@ internal class LogbackLogEvent(
 
   override fun getMarkerList(): List<Marker> = markers
 
-  @Deprecated("Deprecated in ILoggingEvent") override fun getMarker(): Marker? = markers.firstOrNull()
+  @Deprecated("Deprecated in ILoggingEvent")
+  override fun getMarker(): Marker? = markers.firstOrNull()
 
   override fun hasCallerData(): Boolean =
     if (kLoggingEvent.internalCompilerData?.fileName != null) {
@@ -95,7 +96,7 @@ internal class LogbackLogEvent(
   }
 
   override fun toString(): String {
-      return "LogbackLogEvent(level=${level}, message=${message})"
+    return "LogbackLogEvent(level=${level}, message=${message})"
   }
 
   companion object {


### PR DESCRIPTION
# Fix Proguard `IncompleteClassHierarchyException` with Logback 

issue #496

### Issue Description
Users upgrading to `kotlin-logging` versions newer than 7.0.0 encounter a build failure when using Proguard or R8. The error occurs specifically when `logback-classic` is not on the classpath (or is minimized/obfuscated), leading to:

```
error[1004]: proguard.evaluation.exception.IncompleteClassHierarchyException
--> io/github/oshai/kotlinlogging/logback/internal/LogbackLoggerWrapper : at(...)
Can't find common super class of [io.github.oshai.kotlinlogging.Level] ... and [io.github.oshai.kotlinlogging.logback.internal.LogbackLogEvent]
```

### Root Cause
The `LogbackLogEvent` class (internal) extended the concrete class `ch.qos.logback.classic.spi.LoggingEvent`.

When Proguard analyzes bytecode in `LogbackLoggerWrapper`, it often reuses stack slots (e.g., storing a `Level` object and then reusing the same slot for a `LogbackLogEvent` object). To verify this reuse is safe, Proguard calculates the "Common Super Class" of both types.

*   To find the parent of `LogbackLogEvent`, Proguard **must** load its superclass `LoggingEvent`.
*   If `logback-classic` is missing (optional dependency), Proguard fails to load `LoggingEvent` and cannot resolve the hierarchy, causing the crash.

### The Fix
Refactored `LogbackLogEvent` to **implement the `ILoggingEvent` interface directly** instead of extending the `LoggingEvent` class.

*   By implementing the interface, `LogbackLogEvent`'s direct superclass becomes `java.lang.Object`.
*   Proguard can now resolve the common super class (which is `Object`) immediately without needing to load or traverse the hierarchy of the missing `LoggingEvent` class.

### Changes
*   `LogbackLogEvent.kt`:
    *   Removed inheritance from `LoggingEvent`.
    *   Added `ILoggingEvent` interface implementation.
    *   Manually implemented all required interface methods (e.g., `getThreadName`, `getLoggerContextVO`, `getArgumentArray`, `getCallerData`, etc.) to delegate to the underlying logger or return standard values.

### Functional Impact
*   **Safe for majority**: Standard Logback appenders use the `ILoggingEvent` interface contract, so logging behavior remains unchanged.
*   **Potential Edge Case**: Custom Appenders that incorrectly cast event objects to the concrete `LoggingEvent` class (instead of using the interface) will now fail with `ClassCastException`. This is considered a bad practice in Logback extensions, as they should rely on the interface.
