### PR TITLE
feat: add configuration to suppress startup message

### DIFF
--- a/src/androidMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/androidMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -36,6 +36,8 @@ public actual object KotlinLoggingConfiguration {
 
   @Volatile public actual var loggerFactory: KLoggerFactory = detectLogger()
 
+  public actual var logStartupMessage: Boolean = true
+
   private fun detectLogger(): KLoggerFactory {
     if (System.getProperty("kotlin-logging-to-android-native") != null) {
       return AndroidNativeLoggerFactory

--- a/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KotlinLogging.kt
+++ b/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KotlinLogging.kt
@@ -24,6 +24,8 @@ public object KotlinLogging {
 
   init {
     val factory = KotlinLoggingConfiguration.loggerFactory
-    println("kotlin-logging: initializing... active logger factory: ${factory::class.simpleName}")
+    if (KotlinLoggingConfiguration.logStartupMessage) {
+      println("kotlin-logging: initializing... active logger factory: ${factory::class.simpleName}")
+    }
   }
 }

--- a/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -8,6 +8,11 @@ public expect object KotlinLoggingConfiguration {
   public var loggerFactory: KLoggerFactory
 
   /**
+   * If true, print the "kotlin-logging: initializing..." message during startup. Default is true.
+   */
+  public var logStartupMessage: Boolean
+
+  /**
    * Configuration for the **Direct Logging** implementation.
    *
    * On JVM/Android/Darwin, this ONLY applies if [loggerFactory] is set to use

--- a/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -7,6 +7,13 @@ public actual object KotlinLoggingConfiguration {
   public var subsystem: AtomicReference<String?> = AtomicReference(null)
   public var category: AtomicReference<String?> = AtomicReference(null)
 
+  private val _logStartupMessage = AtomicReference(true)
+  public actual var logStartupMessage: Boolean
+    get() = _logStartupMessage.value
+    set(value) {
+      _logStartupMessage.value = value
+    }
+
   // Common properties
   public actual val direct: DirectLoggingConfiguration =
     object : DirectLoggingConfiguration {

--- a/src/jsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/jsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,6 +1,8 @@
 package io.github.oshai.kotlinlogging
 
 public actual object KotlinLoggingConfiguration {
+  public actual var logStartupMessage: Boolean = true
+
   public actual val direct: DirectLoggingConfiguration =
     object : DirectLoggingConfiguration {
       private var _logLevel: Level = Level.INFO

--- a/src/jvmMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/jvmMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -11,6 +11,8 @@ public actual object KotlinLoggingConfiguration {
    */
   @Volatile public actual var loggerFactory: KLoggerFactory = detectLogger()
 
+  public actual var logStartupMessage: Boolean = true
+
   public actual val direct: DirectLoggingConfiguration =
     object : DirectLoggingConfiguration {
       @Volatile

--- a/src/jvmTest/kotlin/io/github/oshai/kotlinlogging/StartupMessageTest.kt
+++ b/src/jvmTest/kotlin/io/github/oshai/kotlinlogging/StartupMessageTest.kt
@@ -1,0 +1,17 @@
+package io.github.oshai.kotlinlogging
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class StartupMessageTest {
+
+  @Test
+  fun testApiExistence() {
+    // Verify that the API exists and is mutable
+    assertTrue(KotlinLoggingConfiguration.logStartupMessage)
+    KotlinLoggingConfiguration.logStartupMessage = false
+    assertTrue(!KotlinLoggingConfiguration.logStartupMessage)
+    // Restore default
+    KotlinLoggingConfiguration.logStartupMessage = true
+  }
+}

--- a/src/nativeMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/nativeMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -31,6 +31,13 @@ public actual object KotlinLoggingConfiguration {
         }
     }
 
+  private val _logStartupMessage = AtomicReference(true)
+  public actual var logStartupMessage: Boolean
+    get() = _logStartupMessage.value
+    set(value) {
+      _logStartupMessage.value = value
+    }
+
   public actual interface DirectLoggingConfiguration {
     public actual var logLevel: Level
     public actual var formatter: Formatter

--- a/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -35,4 +35,6 @@ public actual object KotlinLoggingConfiguration {
   }
 
   public actual var loggerFactory: KLoggerFactory = DirectLoggerFactory
+
+  public actual var logStartupMessage: Boolean = true
 }

--- a/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -35,4 +35,6 @@ public actual object KotlinLoggingConfiguration {
   }
 
   public actual var loggerFactory: KLoggerFactory = DirectLoggerFactory
+
+  public actual var logStartupMessage: Boolean = true
 }


### PR DESCRIPTION
Added logStartupMessage property to KotlinLoggingConfiguration to allow disabling the "kotlin-logging: initializing..." message. Implemented logStartupMessage for all platforms (JVM, Android, Darwin, JS, Native, Wasm). Updated KotlinLogging initialization to check logStartupMessage before printing. Fixes #587