### PR TITLE
Fix Darwin historical logs redaction using public format string

### DIFF
--- a/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/DarwinKLogger.kt
+++ b/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/DarwinKLogger.kt
@@ -26,6 +26,9 @@ public class DarwinKLogger(override val name: String, override val underlyingLog
           __dso_handle.ptr,
           underlyingLogger,
           level.toDarwinLevel(),
+          // Use %{public}s to prevent redaction of the log message in historical logs (log show)
+          // See https://github.com/oshai/kotlin-logging/issues/588
+          "%{public}s",
           formattedMessage,
         )
       }


### PR DESCRIPTION
os_log redacts dynamic strings by default in historical logs (viewed via log show) for privacy. This change updates DarwinKLogger
 to use %{public}s as the fixed format string and passes the message as an argument, explicitly marking it as public data to prevent redaction.

Fixes #588