### PR TITLE
feat: add timestamp to KLoggingEvent

### DIFF
--- a/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KLoggingEvent.kt
+++ b/src/commonMain/kotlin/io/github/oshai/kotlinlogging/KLoggingEvent.kt
@@ -1,5 +1,7 @@
 package io.github.oshai.kotlinlogging
 
+import io.github.oshai.kotlinlogging.internal.getCurrentTime
+
 public data class KLoggingEvent(
   public val level: Level,
   public val marker: Marker?,
@@ -7,6 +9,7 @@ public data class KLoggingEvent(
   public val message: String? = null,
   public val cause: Throwable? = null,
   public val payload: Map<String, Any?>? = null,
+  public val timestamp: Long = getCurrentTime(),
 ) {
   public constructor(
     level: Level,

--- a/src/commonMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
+++ b/src/commonMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
@@ -1,0 +1,3 @@
+package io.github.oshai.kotlinlogging.internal
+
+public expect fun getCurrentTime(): Long

--- a/src/commonTest/kotlin/io/github/oshai/kotlinlogging/KLoggingEventTest.kt
+++ b/src/commonTest/kotlin/io/github/oshai/kotlinlogging/KLoggingEventTest.kt
@@ -1,0 +1,20 @@
+package io.github.oshai.kotlinlogging
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class KLoggingEventTest {
+  @Test
+  fun testTimestampIsRecent() {
+    val before = io.github.oshai.kotlinlogging.internal.getCurrentTime()
+    // Wait a small amount to avoid exact equality if resolution is low, or just accept >=
+    val event = KLoggingEvent(Level.INFO, null, "test")
+    val after = io.github.oshai.kotlinlogging.internal.getCurrentTime()
+
+    assertTrue(
+      event.timestamp >= before,
+      "Timestamp ${event.timestamp} should be >= before $before",
+    )
+    assertTrue(event.timestamp <= after, "Timestamp ${event.timestamp} should be <= after $after")
+  }
+}

--- a/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
+++ b/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
@@ -1,0 +1,5 @@
+package io.github.oshai.kotlinlogging.internal
+
+import kotlin.system.getTimeMillis
+
+public actual fun getCurrentTime(): Long = getTimeMillis()

--- a/src/javaMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
+++ b/src/javaMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
@@ -1,0 +1,3 @@
+package io.github.oshai.kotlinlogging.internal
+
+public actual fun getCurrentTime(): Long = System.currentTimeMillis()

--- a/src/jsMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
+++ b/src/jsMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
@@ -1,0 +1,5 @@
+package io.github.oshai.kotlinlogging.internal
+
+import kotlin.js.Date
+
+public actual fun getCurrentTime(): Long = Date.now().toLong()

--- a/src/nativeMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
+++ b/src/nativeMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
@@ -1,0 +1,5 @@
+package io.github.oshai.kotlinlogging.internal
+
+import kotlin.system.getTimeMillis
+
+public actual fun getCurrentTime(): Long = getTimeMillis()

--- a/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
+++ b/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
@@ -1,0 +1,9 @@
+package io.github.oshai.kotlinlogging.internal
+
+public actual fun getCurrentTime(): Long = Date.now().toLong()
+
+private external class Date {
+  companion object {
+    fun now(): Double
+  }
+}

--- a/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
+++ b/src/wasmWasiMain/kotlin/io/github/oshai/kotlinlogging/internal/KLoggingClock.kt
@@ -1,0 +1,23 @@
+package io.github.oshai.kotlinlogging.internal
+
+import kotlin.wasm.WasmImport
+import kotlin.wasm.unsafe.UnsafeWasmMemoryApi
+import kotlin.wasm.unsafe.withScopedMemoryAllocator
+
+public actual fun getCurrentTime(): Long {
+  @OptIn(UnsafeWasmMemoryApi::class)
+  withScopedMemoryAllocator { allocator ->
+    val timestampPtr = allocator.allocate(8) // 64-bit integer
+    val ret =
+      clock_time_get(
+        1, // CLOCKID_REALTIME
+        1000000, // precision: 1ms (in ns)
+        timestampPtr.address.toInt(),
+      )
+    if (ret != 0) return 0L
+    return (timestampPtr.loadLong() / 1_000_000) // ns to ms
+  }
+}
+
+@WasmImport("wasi_snapshot_preview1", "clock_time_get")
+private external fun clock_time_get(clockId: Int, precision: Long, resultPtr: Int): Int


### PR DESCRIPTION
Adds a `timestamp: Long` field to `KLoggingEvent` to capture event time. Implemented via a new internal multiplatform `KLoggingClock` to provide `getCurrentTime()` on all targets (JVM/Android via javaMain, JS, Native, Wasm) without external dependencies.

Fixes #425