### PR TITLE
Fix #598: Allow external configuration of logStartupMessage via Properties and Env Vars

### DIFF
--- a/src/androidMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/androidMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -36,7 +36,10 @@ public actual object KotlinLoggingConfiguration {
 
   @Volatile public actual var loggerFactory: KLoggerFactory = detectLogger()
 
-  public actual var logStartupMessage: Boolean = true
+  public actual var logStartupMessage: Boolean =
+    System.getProperty("kotlin-logging.logStartupMessage")?.toBoolean()
+      ?: System.getenv("KOTLIN_LOGGING_STARTUP_MESSAGE")?.toBoolean()
+      ?: true
 
   private fun detectLogger(): KLoggerFactory {
     if (System.getProperty("kotlin-logging-to-android-native") != null) {

--- a/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,13 +1,22 @@
 package io.github.oshai.kotlinlogging
 
 import kotlin.concurrent.AtomicReference
+import platform.posix.getenv
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.ExperimentalForeignApi
+
+@OptIn(ExperimentalForeignApi::class)
+private fun getEnv(name: String): String? {
+  return getenv(name)?.toKString()
+}
+
 
 public actual object KotlinLoggingConfiguration {
   // Existing Darwin-specific properties
   public var subsystem: AtomicReference<String?> = AtomicReference(null)
   public var category: AtomicReference<String?> = AtomicReference(null)
 
-  private val _logStartupMessage = AtomicReference(true)
+  private val _logStartupMessage = AtomicReference(getEnv("KOTLIN_LOGGING_STARTUP_MESSAGE")?.toBoolean() ?: true)
   public actual var logStartupMessage: Boolean
     get() = _logStartupMessage.value
     set(value) {

--- a/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/darwinMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,22 +1,22 @@
 package io.github.oshai.kotlinlogging
 
 import kotlin.concurrent.AtomicReference
-import platform.posix.getenv
-import kotlinx.cinterop.toKString
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
 
 @OptIn(ExperimentalForeignApi::class)
 private fun getEnv(name: String): String? {
   return getenv(name)?.toKString()
 }
 
-
 public actual object KotlinLoggingConfiguration {
   // Existing Darwin-specific properties
   public var subsystem: AtomicReference<String?> = AtomicReference(null)
   public var category: AtomicReference<String?> = AtomicReference(null)
 
-  private val _logStartupMessage = AtomicReference(getEnv("KOTLIN_LOGGING_STARTUP_MESSAGE")?.toBoolean() ?: true)
+  private val _logStartupMessage =
+    AtomicReference(getEnv("KOTLIN_LOGGING_STARTUP_MESSAGE")?.toBoolean() ?: true)
   public actual var logStartupMessage: Boolean
     get() = _logStartupMessage.value
     set(value) {

--- a/src/jsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/jsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -2,16 +2,24 @@ package io.github.oshai.kotlinlogging
 
 private fun resolveStartupMessageDefault(): Boolean {
   try {
-    val disabledInWindow = js("typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+    val disabledInWindow =
+      js(
+        "typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)"
+      )
+        as Boolean
     if (disabledInWindow) {
       return false
     }
-    
-    val disabledInEnv = js("typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+
+    val disabledInEnv =
+      js(
+        "typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)"
+      )
+        as Boolean
     if (disabledInEnv) {
       return false
     }
-    
+
     return true
   } catch (e: Throwable) {
     return true

--- a/src/jsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/jsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,7 +1,25 @@
 package io.github.oshai.kotlinlogging
 
+private fun resolveStartupMessageDefault(): Boolean {
+  try {
+    val disabledInWindow = js("typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+    if (disabledInWindow) {
+      return false
+    }
+    
+    val disabledInEnv = js("typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+    if (disabledInEnv) {
+      return false
+    }
+    
+    return true
+  } catch (e: Throwable) {
+    return true
+  }
+}
+
 public actual object KotlinLoggingConfiguration {
-  public actual var logStartupMessage: Boolean = true
+  public actual var logStartupMessage: Boolean = resolveStartupMessageDefault()
 
   public actual val direct: DirectLoggingConfiguration =
     object : DirectLoggingConfiguration {

--- a/src/jvmMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/jvmMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -11,7 +11,10 @@ public actual object KotlinLoggingConfiguration {
    */
   @Volatile public actual var loggerFactory: KLoggerFactory = detectLogger()
 
-  public actual var logStartupMessage: Boolean = true
+  public actual var logStartupMessage: Boolean =
+    System.getProperty("kotlin-logging.logStartupMessage")?.toBoolean()
+      ?: System.getenv("KOTLIN_LOGGING_STARTUP_MESSAGE")?.toBoolean()
+      ?: true
 
   public actual val direct: DirectLoggingConfiguration =
     object : DirectLoggingConfiguration {

--- a/src/nativeMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/nativeMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,15 +1,14 @@
 package io.github.oshai.kotlinlogging
 
 import kotlin.concurrent.AtomicReference
-import platform.posix.getenv
-import kotlinx.cinterop.toKString
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
 
 @OptIn(ExperimentalForeignApi::class)
 private fun getEnv(name: String): String? {
   return getenv(name)?.toKString()
 }
-
 
 public actual object KotlinLoggingConfiguration {
   public actual val direct: DirectLoggingConfiguration =
@@ -40,7 +39,8 @@ public actual object KotlinLoggingConfiguration {
         }
     }
 
-  private val _logStartupMessage = AtomicReference(getEnv("KOTLIN_LOGGING_STARTUP_MESSAGE")?.toBoolean() ?: true)
+  private val _logStartupMessage =
+    AtomicReference(getEnv("KOTLIN_LOGGING_STARTUP_MESSAGE")?.toBoolean() ?: true)
   public actual var logStartupMessage: Boolean
     get() = _logStartupMessage.value
     set(value) {

--- a/src/nativeMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/nativeMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,6 +1,15 @@
 package io.github.oshai.kotlinlogging
 
 import kotlin.concurrent.AtomicReference
+import platform.posix.getenv
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.ExperimentalForeignApi
+
+@OptIn(ExperimentalForeignApi::class)
+private fun getEnv(name: String): String? {
+  return getenv(name)?.toKString()
+}
+
 
 public actual object KotlinLoggingConfiguration {
   public actual val direct: DirectLoggingConfiguration =
@@ -31,7 +40,7 @@ public actual object KotlinLoggingConfiguration {
         }
     }
 
-  private val _logStartupMessage = AtomicReference(true)
+  private val _logStartupMessage = AtomicReference(getEnv("KOTLIN_LOGGING_STARTUP_MESSAGE")?.toBoolean() ?: true)
   public actual var logStartupMessage: Boolean
     get() = _logStartupMessage.value
     set(value) {

--- a/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,23 +1,21 @@
 package io.github.oshai.kotlinlogging
 
-private val startupMessageDisabledInWindow: Boolean =
+private fun startupMessageDisabledInWindow(): Boolean =
   js(
     "typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)"
   )
-    as Boolean
 
-private val startupMessageDisabledInEnv: Boolean =
+private fun startupMessageDisabledInEnv(): Boolean =
   js(
     "typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)"
   )
-    as Boolean
 
 private fun resolveStartupMessageDefault(): Boolean {
   try {
-    if (startupMessageDisabledInWindow) {
+    if (startupMessageDisabledInWindow()) {
       return false
     }
-    if (startupMessageDisabledInEnv) {
+    if (startupMessageDisabledInEnv()) {
       return false
     }
     return true

--- a/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,5 +1,23 @@
 package io.github.oshai.kotlinlogging
 
+private fun resolveStartupMessageDefault(): Boolean {
+  try {
+    val disabledInWindow = js("typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+    if (disabledInWindow) {
+      return false
+    }
+    
+    val disabledInEnv = js("typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+    if (disabledInEnv) {
+      return false
+    }
+    
+    return true
+  } catch (e: Throwable) {
+    return true
+  }
+}
+
 public actual object KotlinLoggingConfiguration {
   public actual val direct: DirectLoggingConfiguration =
     object : DirectLoggingConfiguration {
@@ -36,5 +54,5 @@ public actual object KotlinLoggingConfiguration {
 
   public actual var loggerFactory: KLoggerFactory = DirectLoggerFactory
 
-  public actual var logStartupMessage: Boolean = true
+  public actual var logStartupMessage: Boolean = resolveStartupMessageDefault()
 }

--- a/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,10 +1,16 @@
 package io.github.oshai.kotlinlogging
 
 private val startupMessageDisabledInWindow: Boolean =
-  js("typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+  js(
+    "typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)"
+  )
+    as Boolean
 
 private val startupMessageDisabledInEnv: Boolean =
-  js("typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+  js(
+    "typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)"
+  )
+    as Boolean
 
 private fun resolveStartupMessageDefault(): Boolean {
   try {

--- a/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,17 +1,17 @@
 package io.github.oshai.kotlinlogging
 
-private fun startupMessageDisabledInWindow(): Boolean =
+private val startupMessageDisabledInWindow: Boolean =
   js("typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
 
-private fun startupMessageDisabledInEnv(): Boolean =
+private val startupMessageDisabledInEnv: Boolean =
   js("typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
 
 private fun resolveStartupMessageDefault(): Boolean {
   try {
-    if (startupMessageDisabledInWindow()) {
+    if (startupMessageDisabledInWindow) {
       return false
     }
-    if (startupMessageDisabledInEnv()) {
+    if (startupMessageDisabledInEnv) {
       return false
     }
     return true

--- a/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
+++ b/src/wasmJsMain/kotlin/io/github/oshai/kotlinlogging/KotlinLoggingConfiguration.kt
@@ -1,17 +1,19 @@
 package io.github.oshai.kotlinlogging
 
+private fun startupMessageDisabledInWindow(): Boolean =
+  js("typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+
+private fun startupMessageDisabledInEnv(): Boolean =
+  js("typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
+
 private fun resolveStartupMessageDefault(): Boolean {
   try {
-    val disabledInWindow = js("typeof window !== 'undefined' && (window.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || window.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
-    if (disabledInWindow) {
+    if (startupMessageDisabledInWindow()) {
       return false
     }
-    
-    val disabledInEnv = js("typeof process !== 'undefined' && process.env && (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === 'false' || process.env.KOTLIN_LOGGING_STARTUP_MESSAGE === false)") as Boolean
-    if (disabledInEnv) {
+    if (startupMessageDisabledInEnv()) {
       return false
     }
-    
     return true
   } catch (e: Throwable) {
     return true


### PR DESCRIPTION
Addresses #598 by adding support for configuring KotlinLoggingConfiguration.logStartupMessage externally via System Properties and Environment Variables across all supported Kotlin Multiplatform platforms.

Currently, disabling the startup message programmatically can be awkward or impossible if top-level loggers initialize KotlinLogging during class loading before main() or test setups have a chance to run. Providing external configuration flags completely bypasses this initialization order constraint.

To maintain backward compatibility and avoid confusing users who rely on startup diagnostics, the default behavior remains true (opt-out).

Cross-Platform Implementation Details
The default value for logStartupMessage is now dynamically resolved during initialization based on the platform:

JVM & Android: Checks the JVM System Property kotlin-logging.logStartupMessage first, then falls back to the Environment Variable KOTLIN_LOGGING_STARTUP_MESSAGE.
Native & Darwin: Uses POSIX getenv to check the KOTLIN_LOGGING_STARTUP_MESSAGE environment variable.
JS & Wasm JS: Safely evaluates the Browser environment (window.KOTLIN_LOGGING_STARTUP_MESSAGE) or Node.js environment (process.env.KOTLIN_LOGGING_STARTUP_MESSAGE). Returns false if either resolves to "false" or boolean false.


Fixes #598